### PR TITLE
Changed CVV textfield keyboard type to asciiCapableNumberPad

### DIFF
--- a/Source/CardView.swift
+++ b/Source/CardView.swift
@@ -95,7 +95,6 @@ public class CardView: UIView {
         cardNumberInputView.textField.placeholder = "4242"
         expirationDateInputView.textField.placeholder = "06/20"
         cvvInputView.textField.placeholder = "100"
-        cvvInputView.textField.keyboardType = .numberPad
 
         schemeIconsStackView.spacing = 8
         stackView.axis = .vertical

--- a/Source/CvvInputView.swift
+++ b/Source/CvvInputView.swift
@@ -29,7 +29,7 @@ import UIKit
     // MARK: - Setup
 
     private func setup() {
-        textField.keyboardType = .numberPad
+        textField.keyboardType = .asciiCapableNumberPad
         textField.textContentType = nil
         textField.delegate = self
         textField.addTarget(self, action: #selector(textFieldDidChange), for: UIControl.Event.editingChanged)

--- a/Tests/CvvInputViewTests.swift
+++ b/Tests/CvvInputViewTests.swift
@@ -16,17 +16,20 @@ class CvvInputViewTests: XCTestCase {
     func testEmptyInitialization() {
         let cvvInputView = CvvInputView()
         XCTAssertNil(cvvInputView.textField.textContentType)
+        XCTAssertEqual(cvvInputView.textField.keyboardType, .asciiCapableNumberPad)
     }
 
     func testCoderInitialization() {
         let coder = NSKeyedUnarchiver(forReadingWith: Data())
         let cvvInputView = CvvInputView(coder: coder)
         XCTAssertNil(cvvInputView!.textField.textContentType)
+        XCTAssertEqual(cvvInputView!.textField.keyboardType, .asciiCapableNumberPad)
     }
 
     func testFrameInitialization() {
         let cvvInputView = CvvInputView(frame: CGRect(x: 0, y: 0, width: 400, height: 48))
         XCTAssertNil(cvvInputView.textField.textContentType)
+        XCTAssertEqual(cvvInputView.textField.keyboardType, .asciiCapableNumberPad)
     }
 
     func testDoNotChangeCvvIfExceedingMaxLength() {

--- a/Tests/Views/CardViewTests.swift
+++ b/Tests/Views/CardViewTests.swift
@@ -9,11 +9,13 @@ class CardViewTests: XCTestCase {
         XCTAssertNotNil(cardView)
         XCTAssertEqual(cardView?.cardHolderNameState, InputState.required)
         XCTAssertEqual(cardView?.billingDetailsState, InputState.required)
+        XCTAssertEqual(cardView?.cvvInputView.textField.keyboardType, .asciiCapableNumberPad)
     }
 
     func testFrameInitialization() {
         let cardView = CardView(frame: CGRect(x: 0, y: 0, width: 400, height: 48))
         XCTAssertEqual(cardView.cardHolderNameState, InputState.required)
         XCTAssertEqual(cardView.billingDetailsState, InputState.required)
+        XCTAssertEqual(cardView.cvvInputView.textField.keyboardType, .asciiCapableNumberPad)
     }
 }


### PR DESCRIPTION
- Updated unit tests

## Proposed changes

This bug fix forces the English numberpad for the cvv input `textField`.  The bug it fixes allowed users with non-English numberpads to enter different characters, e.g. Arabic.

## Types of changes

* [x ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
* [x ] Lint and unit tests pass locally with my changes
* [x ] I have added tests that prove my fix is effective or that my feature works
* [x ] I have added necessary documentation (if appropriate)