### PR TITLE
MPI-243 : Fix for Edit phone number back space causing crash

### DIFF
--- a/Source/PhoneNumberInputView.swift
+++ b/Source/PhoneNumberInputView.swift
@@ -71,13 +71,20 @@ import UIKit
             if targetCursorPosition != 0 {
                 let lastChar = formatted.substring(with: NSRange(location: targetCursorPosition - 1, length: 1))
                 if lastChar == " " && previousTextCount < formatted.count && phoneNumber != formatted {
-                    targetPosition = textField
-                        .position(from: textField.beginningOfDocument, offset: targetCursorPosition + 1)!
+                    guard let aTargetPosition = textField.position(from: textField.beginningOfDocument,
+                                                                   offset: targetCursorPosition + 1) else {
+                                                                    return
+                    }
+                    targetPosition = aTargetPosition
                 }
             }
-            if (previousFormat.filter{$0 == " "}.count != formatted.filter{$0 == " "}.count) && phoneNumber != formatted {
-                targetPosition = textField
-                    .position(from: textField.beginningOfDocument, offset: targetCursorPosition + 1)!
+            if (previousFormat.filter {$0 == " "}.count != formatted.filter {$0 == " "}.count) &&
+                phoneNumber != formatted {
+                guard let aTargetPosition = textField.position(from: textField.beginningOfDocument,
+                                                               offset: targetCursorPosition + 1) else {
+                                                                return
+                }
+                targetPosition = aTargetPosition
             }
             textField.selectedTextRange = textField.textRange(from: targetPosition, to: targetPosition)
         }


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments

Fixed crash causing due to force wrapping a nil value when use back space for phone number text field. 
