### PR TITLE
Remove PhoneNumberKit update.sh file

### DIFF
--- a/FramesIos.xcodeproj/project.pbxproj
+++ b/FramesIos.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		8EA7FB6C2539B570002DF39F /* ParseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA7FB542539B570002DF39F /* ParseManager.swift */; };
 		8EA7FB6D2539B570002DF39F /* PhoneNumberMetadata.xml in Resources */ = {isa = PBXBuildFile; fileRef = 8EA7FB572539B570002DF39F /* PhoneNumberMetadata.xml */; };
 		8EA7FB6E2539B570002DF39F /* PhoneNumberMetadata.json in Resources */ = {isa = PBXBuildFile; fileRef = 8EA7FB582539B570002DF39F /* PhoneNumberMetadata.json */; };
-		8EA7FB702539B570002DF39F /* update.sh in Resources */ = {isa = PBXBuildFile; fileRef = 8EA7FB5A2539B570002DF39F /* update.sh */; };
 		8EA7FB712539B570002DF39F /* PhoneNumberKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EA7FB5B2539B570002DF39F /* PhoneNumberKit.h */; };
 		8EA7FB722539B570002DF39F /* NSRegularExpression+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA7FB5C2539B570002DF39F /* NSRegularExpression+Swift.swift */; };
 		8EA7FB732539B570002DF39F /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA7FB5D2539B570002DF39F /* Formatter.swift */; };
@@ -190,7 +189,6 @@
 		8EA7FB542539B570002DF39F /* ParseManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseManager.swift; sourceTree = "<group>"; };
 		8EA7FB572539B570002DF39F /* PhoneNumberMetadata.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PhoneNumberMetadata.xml; sourceTree = "<group>"; };
 		8EA7FB582539B570002DF39F /* PhoneNumberMetadata.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PhoneNumberMetadata.json; sourceTree = "<group>"; };
-		8EA7FB5A2539B570002DF39F /* update.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = update.sh; sourceTree = "<group>"; };
 		8EA7FB5B2539B570002DF39F /* PhoneNumberKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhoneNumberKit.h; sourceTree = "<group>"; };
 		8EA7FB5C2539B570002DF39F /* NSRegularExpression+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRegularExpression+Swift.swift"; sourceTree = "<group>"; };
 		8EA7FB5D2539B570002DF39F /* Formatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
@@ -392,7 +390,6 @@
 			children = (
 				8EA7FB562539B570002DF39F /* Original */,
 				8EA7FB582539B570002DF39F /* PhoneNumberMetadata.json */,
-				8EA7FB5A2539B570002DF39F /* update.sh */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -852,7 +849,6 @@
 				E6AF0A3D20AAE46600D29929 /* schemes in Resources */,
 				8EA7FB6E2539B570002DF39F /* PhoneNumberMetadata.json in Resources */,
 				E6AF0A2F20AADFF700D29929 /* arrows in Resources */,
-				8EA7FB702539B570002DF39F /* update.sh in Resources */,
 				E625EE672090926F0019B750 /* LICENSE in Resources */,
 				E658531820D7C83600C261D7 /* iOS Example Frames.md in Resources */,
 				E64B31E020D26A930088B7FD /* ckoCardToken.json in Resources */,

--- a/Source/PhoneNumberKit/Resources/update.sh
+++ b/Source/PhoneNumberKit/Resources/update.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-python -m xmljson -o PhoneNumberMetadataTemp.json -d yahoo "$(pwd)/Original/PhoneNumberMetadata.xml"
-cat PhoneNumberMetadataTemp.json | sed 's/\\n//g' | sed 's/ \{3,\}//g' | sed 's/   //g' | tr -d "\n" > PhoneNumberMetadata.json
-rm PhoneNumberMetadataTemp.json
-


### PR DESCRIPTION
## Proposed changes

This PR removes `update.sh` from the project which is causing App Store rejections. This was added when updating PhoneNumberKit.

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [X] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)