### PR TITLE
PIMOB-347: Add NetworkError tests

### DIFF
--- a/FramesIos.xcodeproj/project.pbxproj
+++ b/FramesIos.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		8EA7FB762539B570002DF39F /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA7FB602539B570002DF39F /* PhoneNumberFormatter.swift */; };
 		8EA7FB772539B570002DF39F /* PhoneNumberKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA7FB612539B570002DF39F /* PhoneNumberKit.swift */; };
 		8EA7FB792539B570002DF39F /* PhoneNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA7FB632539B570002DF39F /* PhoneNumberParser.swift */; };
+		8ED1258D2577D03500909D80 /* NetworkErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ED1258C2577D03500909D80 /* NetworkErrorTests.swift */; };
 		C05921A046069B80E37C8799 /* Pods_FramesIosTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 960B3E65C846C45B1B539F24 /* Pods_FramesIosTests.framework */; };
 		CF0E2BDE2366039C000C3418 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0E2BDB2366039B000C3418 /* Customer.swift */; };
 		CF0E2BDF2366039C000C3418 /* CustomerCardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0E2BDC2366039B000C3418 /* CustomerCardList.swift */; };
@@ -199,6 +200,7 @@
 		8EA7FB602539B570002DF39F /* PhoneNumberFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberFormatter.swift; sourceTree = "<group>"; };
 		8EA7FB612539B570002DF39F /* PhoneNumberKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberKit.swift; sourceTree = "<group>"; };
 		8EA7FB632539B570002DF39F /* PhoneNumberParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberParser.swift; sourceTree = "<group>"; };
+		8ED1258C2577D03500909D80 /* NetworkErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorTests.swift; sourceTree = "<group>"; };
 		960B3E65C846C45B1B539F24 /* Pods_FramesIosTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FramesIosTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF0E2BDB2366039B000C3418 /* Customer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		CF0E2BDC2366039B000C3418 /* CustomerCardList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerCardList.swift; sourceTree = "<group>"; };
@@ -641,6 +643,7 @@
 			children = (
 				E67AB96D208DF9D800593FBE /* CardUtilsTests.swift */,
 				E67AB997208E2BBA00593FBE /* CheckoutAPIClientTests.swift */,
+				8ED1258C2577D03500909D80 /* NetworkErrorTests.swift */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -1082,6 +1085,7 @@
 				E64B31EC20D2D2FF0088B7FD /* AddressViewTests.swift in Sources */,
 				E6AF0A1020AAD00600D29929 /* ExpirationDateInputViewTests.swift in Sources */,
 				E67AB998208E2BBA00593FBE /* CheckoutAPIClientTests.swift in Sources */,
+				8ED1258D2577D03500909D80 /* NetworkErrorTests.swift in Sources */,
 				E6FC280020D8F68300809458 /* SimpleLoadingViewControllerTests.swift in Sources */,
 				E64B31DC20D1810F0088B7FD /* SchemeIconsStackViewTests.swift in Sources */,
 				E658532220D8076E00C261D7 /* AddressViewControllerMockDelegate.swift in Sources */,

--- a/Source/NetworkError.swift
+++ b/Source/NetworkError.swift
@@ -13,13 +13,17 @@ public enum NetworkError: Error, Decodable {
     }
     
     public init(from decoder: Decoder) throws {
+
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        if let requestId = try? values.decode(String.self, forKey: .requestId),
-           let errorType = try? values.decode(String.self, forKey: .errorType),
-           let errorCodes = try? values.decode([String].self, forKey: .errorCodes) {
-            self = .checkout(requestId: requestId, errorType: errorType, errorCodes: errorCodes)
+
+        guard let requestId = try? values.decode(String.self, forKey: .requestId),
+              let errorType = try? values.decode(String.self, forKey: .errorType),
+              let errorCodes = try? values.decode([String].self, forKey: .errorCodes) else {
+
+            self = .unknown
+            return
         }
-        self = .unknown
+
+        self = .checkout(requestId: requestId, errorType: errorType, errorCodes: errorCodes)
     }
-    
 }

--- a/Tests/NetworkErrorTests.swift
+++ b/Tests/NetworkErrorTests.swift
@@ -1,0 +1,119 @@
+//
+//  NetworkErrorTests.swift
+//  FramesIosTests
+//
+//  Created by Daven.Gomes on 02/12/2020.
+//  Copyright © 2020 Checkout. All rights reserved.
+//
+
+import XCTest
+@testable import FramesIos
+
+final class NetworkErrorTests: XCTestCase {
+
+    func test_init_allValuesExist_checkoutErrorReturned() {
+
+        let responseJSON = makeResponseJSON(
+            requestID: "stubRequestID",
+            errorType: "stubErrorType",
+            errorCodes: ["stubErrorCode1",
+                         "stubErrorCode2"]
+        )
+
+        do {
+
+            let data = try JSONSerialization.data(withJSONObject: responseJSON, options: .prettyPrinted)
+            let result = try JSONDecoder().decode(NetworkError.self, from: data)
+
+            guard case .checkout(let requestId, let errorType, let errorCodes) = result else {
+                return XCTFail("Unexpected NetworkError type.")
+            }
+
+            XCTAssertEqual(requestId, "stubRequestID")
+            XCTAssertEqual(errorType, "stubErrorType")
+            XCTAssertEqual(errorCodes, ["stubErrorCode1",
+                                        "stubErrorCode2"])
+
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func test_init_requestIDNil_returnUnknown() {
+
+        let responseJSON = makeResponseJSON(
+            requestID: nil,
+            errorType: "stubErrorType",
+            errorCodes: ["stubErrorCode1",
+                         "stubErrorCode2"]
+        )
+
+        do {
+
+            let data = try JSONSerialization.data(withJSONObject: responseJSON, options: .prettyPrinted)
+            let result = try JSONDecoder().decode(NetworkError.self, from: data)
+
+            guard case .unknown = result else {
+                return XCTFail("Unexpected NetworkError type.")
+            }
+
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func test_init_errorTypeNil_returnUnknown() {
+
+        let responseJSON = makeResponseJSON(
+            requestID: "stubRequestID",
+            errorType: nil,
+            errorCodes: ["stubErrorCode1",
+                         "stubErrorCode2"]
+        )
+
+        do {
+
+            let data = try JSONSerialization.data(withJSONObject: responseJSON, options: .prettyPrinted)
+            let result = try JSONDecoder().decode(NetworkError.self, from: data)
+
+            guard case .unknown = result else {
+                return XCTFail("Unexpected NetworkError type.")
+            }
+
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func test_init_errorTypeErrorCodes_returnUnknown() {
+
+        let responseJSON = makeResponseJSON(
+            requestID: "stubRequestID",
+            errorType: "stubErrorType",
+            errorCodes: nil
+        )
+
+        do {
+
+            let data = try JSONSerialization.data(withJSONObject: responseJSON, options: .prettyPrinted)
+            let result = try JSONDecoder().decode(NetworkError.self, from: data)
+
+            guard case .unknown = result else {
+                return XCTFail("Unexpected NetworkError type.")
+            }
+
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+
+    private func makeResponseJSON(requestID: String? = nil,
+                                  errorType: String? = nil,
+                                  errorCodes: [String]? = nil) -> [String: Any?] {
+
+        return ["request_id": requestID,
+                "error_type": errorType,
+                "error_codes": errorCodes]
+    }
+}


### PR DESCRIPTION
## Proposed changes

Fix logic in `NetworkError` where it would always return `.unknown` in the `init` method.
Add unit tests for `NetworkError`.

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [X] Bugfix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)