### PR TITLE
Enable customization of chevron color

### DIFF
--- a/Documentation/Customizing the Card View.md
+++ b/Documentation/Customizing the Card View.md
@@ -13,6 +13,7 @@ You can modify the card view after the initialization.
         CheckoutTheme.secondaryBackgroundColor = .purple
         CheckoutTheme.errorColor = .yellow
         CheckoutTheme.color = .green
+        CheckoutTheme.chevronColor = .pink
         return CardViewController(cardHolderNameState: .hidden, billingDetailsState: .normal)
     }
 ```

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ var cardViewController: CardViewController {
     CheckoutTheme.secondaryBackgroundColor = .purple
     CheckoutTheme.errorColor = .yellow
     CheckoutTheme.color = .green
+    CheckoutTheme.chevronColor = .pink
     return CardViewController(checkoutApiClient: checkoutAPIClient, cardHolderNameState: .hidden, billingDetailsState: .normal)
 }
 ```

--- a/Source/CheckoutTheme.swift
+++ b/Source/CheckoutTheme.swift
@@ -14,6 +14,8 @@ public class CheckoutTheme {
     public static var secondaryColor: UIColor = .lightGray
     /// Error text color
     public static var errorColor: UIColor = .red
+    /// Chevron color
+    public static var chevronColor: UIColor = .black
     /// Font
     public static var font: UIFont = UIFont.systemFont(ofSize: UIFont.systemFontSize)
     /// Bar style, used for the search bar

--- a/Source/DetailsInputView.swift
+++ b/Source/DetailsInputView.swift
@@ -48,8 +48,9 @@ import UIKit
         self.button = UIButton(type: .contactAdd)
         value.text = "value"
         #else
-        let image = "arrows/keyboard-next".image(forClass: DetailsInputView.self)
+        let image = "arrows/keyboard-next".image(forClass: DetailsInputView.self).withRenderingMode(.alwaysTemplate)
         button.setImage(image, for: .normal)
+        button.tintColor = CheckoutTheme.chevronColor
         #endif
         // add to view
         stackView.axis = .horizontal

--- a/Tests/DetailsInputViewTests.swift
+++ b/Tests/DetailsInputViewTests.swift
@@ -3,13 +3,6 @@ import XCTest
 
 class DetailsInputViewTests: XCTestCase {
 
-    var detailsInputView = DetailsInputView()
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-        detailsInputView = DetailsInputView()
-    }
-
     func testEmptyInitialization() {
         _ = DetailsInputView()
     }
@@ -24,13 +17,31 @@ class DetailsInputViewTests: XCTestCase {
     }
 
     func testSetText() {
+        let detailsInputView = DetailsInputView()
         detailsInputView.text = "Text"
         XCTAssertEqual(detailsInputView.label.text, "Text")
     }
 
     func testSetLabelAndBackgroundColor() {
+        let detailsInputView = DetailsInputView()
         detailsInputView.set(label: "addressLine1", backgroundColor: .white)
         XCTAssertEqual(detailsInputView.label.text, "Address line 1*")
         XCTAssertEqual(detailsInputView.backgroundColor, UIColor.white)
+    }
+
+    func testChevronRenderingMode() {
+        let detailsInputView = DetailsInputView()
+        XCTAssertEqual(detailsInputView.button.image(for: .normal)?.renderingMode, .alwaysTemplate)
+    }
+
+    func testDefaultChevronColor() {
+        CheckoutTheme.chevronColor = .cyan
+        let detailsInputView = DetailsInputView()
+        XCTAssertEqual(detailsInputView.button.tintColor, .cyan)
+    }
+
+    func testCustomizedChevronColor() {
+        let detailsInputView = DetailsInputView()
+        XCTAssertEqual(detailsInputView.button.tintColor, .black)
     }
 }


### PR DESCRIPTION
## Proposed changes

This relates to issue https://github.com/checkout/frames-ios/issues/39.

Currently, there is no way of customizing the chevron colour, so it's difficult to get a dark mode looking right. This PR adds a property to `CheckoutTheme` that allows the modification of the color that will be applied to the chevron image. This defaults to `.black`, to maintain backwards compatibility.

## Types of changes

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

* [ ] Lint and unit tests pass locally with my changes

Existing linting errors exist, but this change does not introduce any new ones. Unit tests pass.

* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)
