### PR TITLE
fix: arrows and checkmarks not loading for SPM due to resource structure

### DIFF
--- a/Source/UI/CardListCell.swift
+++ b/Source/UI/CardListCell.swift
@@ -67,7 +67,7 @@ public class CardListCell: UITableViewCell {
     /// Sets the selected state of the cell, optionally animating the transition between states.
     override public func setSelected(_ selected: Bool, animated: Bool) {
         if selected {
-            let image = "checkmarks/checkmark".image(forClass: CardListCell.self)
+            let image = "checkmark".image(forClass: CardListCell.self)
             selectedImageView.image = image
         } else {
             selectedImageView.image = nil

--- a/Source/UI/Views/DetailsInputView.swift
+++ b/Source/UI/Views/DetailsInputView.swift
@@ -48,7 +48,7 @@ import UIKit
         self.button = UIButton(type: .contactAdd)
         value.text = "value"
         #else
-        let image = "arrows/keyboard-next".image(forClass: DetailsInputView.self).withRenderingMode(.alwaysTemplate)
+        let image = "keyboard-next".image(forClass: DetailsInputView.self).withRenderingMode(.alwaysTemplate)
         button.setImage(image, for: .normal)
         button.tintColor = CheckoutTheme.chevronColor
         #endif


### PR DESCRIPTION
## Issues

- Arrows and checkmarks were not loading for SPM due to reliance on resource structure (which SPM removes)

## Changes

- Access arrows and checkmarks by file name only

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [X] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
