### PR TITLE
PIMOB-738: fix keychain loader issue during tests

### DIFF
--- a/Frames.podspec
+++ b/Frames.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
   s.test_spec do |t|
     t.source_files = 'Tests/**/*.swift'
     t.resources = 'Tests/Fixtures/*'
+    t.requires_app_host = true
   end
 
   s.pod_target_xcconfig = { 'VALID_ARCHS' => 'arm64 armv7 x86_64' }

--- a/Tests/Core/CheckoutAPIClientTests.swift
+++ b/Tests/Core/CheckoutAPIClientTests.swift
@@ -323,8 +323,7 @@ final class CheckoutAPIClientTests: XCTestCase {
     }
     
     // MARK: - buildRemoteProcessorMetadata
-    #if SWIFT_PACKAGE
-    #else
+    #if !SWIFT_PACKAGE
     func testRemoteProcessorMetadata() {
         let stubUIDevice = StubUIDevice(modelName: "modelName", systemVersion: "systemVersion")
 

--- a/Tests/Core/CheckoutAPIClientTests.swift
+++ b/Tests/Core/CheckoutAPIClientTests.swift
@@ -323,7 +323,8 @@ final class CheckoutAPIClientTests: XCTestCase {
     }
     
     // MARK: - buildRemoteProcessorMetadata
-    
+    #if SWIFT_PACKAGE
+    #else
     func testRemoteProcessorMetadata() {
         let stubUIDevice = StubUIDevice(modelName: "modelName", systemVersion: "systemVersion")
 
@@ -343,7 +344,8 @@ final class CheckoutAPIClientTests: XCTestCase {
 
         XCTAssertEqual(subject, expected)
     }
-    
+    #endif
+
     // MARK: - Utility
     
     private func createSubject(publicKey: String = "",

--- a/iOS Example Frame Carthage/iOS Example Frame Carthage.xcodeproj/project.pbxproj
+++ b/iOS Example Frame Carthage/iOS Example Frame Carthage.xcodeproj/project.pbxproj
@@ -217,6 +217,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4407DC4126CD0AB700BA4B06 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E6646F8220CE6C0900D8353A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E6646F8920CE6C0900D8353A;
+			remoteInfo = "iOS Example Frame";
+		};
 		4422777026163748009626A0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E6646F8220CE6C0900D8353A /* Project object */;
@@ -992,6 +999,7 @@
 			);
 			dependencies = (
 				57256C80269F1181001EC3D8 /* PBXTargetDependency */,
+				4407DC4226CD0AB700BA4B06 /* PBXTargetDependency */,
 			);
 			name = FramesTests;
 			productName = FramesTests;
@@ -1056,6 +1064,7 @@
 					};
 					57256C78269F1181001EC3D8 = {
 						CreatedOnToolsVersion = 12.4;
+						TestTargetID = E6646F8920CE6C0900D8353A;
 					};
 					E6646F8920CE6C0900D8353A = {
 						CreatedOnToolsVersion = 9.4;
@@ -1365,6 +1374,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4407DC4226CD0AB700BA4B06 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E6646F8920CE6C0900D8353A /* iOS Example Frame */;
+			targetProxy = 4407DC4126CD0AB700BA4B06 /* PBXContainerItemProxy */;
+		};
 		4422777126163748009626A0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 4422775C26163748009626A0 /* Frames */;
@@ -1528,6 +1542,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS Example Frame.app/iOS Example Frame";
 			};
 			name = Debug;
 		};
@@ -1548,6 +1563,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS Example Frame.app/iOS Example Frame";
 			};
 			name = Release;
 		};

--- a/iOS Example Frame/Podfile.lock
+++ b/iOS Example Frame/Podfile.lock
@@ -28,7 +28,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CheckoutEventLoggerKit: 9a5aabfc739e5a75fb28da83ea1e0aae4a13d254
-  Frames: 7770eec8a15a369ac177a84be2c8afc7a55bde46
+  Frames: ab7d74f551db68a3bdc56c862ea4fc518e5870c5
   PhoneNumberKit: 4ce83273551c4d2ae10b7361162f4283dd02835f
 
 PODFILE CHECKSUM: 0935f6adf6dbf24cd1aebd515551bbce53bef8e5


### PR DESCRIPTION
## Proposed changes

Add app host for unit tests. This fixes an issue in Xcode 13 where we are unable to use the keychain without an app host.

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [X] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)