### PR TITLE
Fix up the .podspec to always bundle the resources

### DIFF
--- a/Frames.podspec
+++ b/Frames.podspec
@@ -15,7 +15,9 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Source/**/*.swift'
   s.exclude_files = "Classes/Exclude"
-  s.resources = 'Source/Resources/**/*'
+  s.resource_bundles = {
+		'Frames' => ['Source/Resources/**/*']
+	}
 
   s.dependency 'PhoneNumberKit', '~> 3.3'
   s.dependency 'CheckoutEventLoggerKit', '~> 1.0'


### PR DESCRIPTION
This is to address issue #111.

The code already looks up for resources in `Frames.bundle`, so tweaking the .podspec to generate the resource bundle fixes the issue with resource clashes when the pod is linked statically.