### PR TITLE
Fix: Change the background colour of the whole page

### DIFF
--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/AddressLine1/DefaultBillingFormAddressLine1CellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/AddressLine1/DefaultBillingFormAddressLine1CellStyle.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public struct DefaultBillingFormAddressLine1CellStyle: CellTextFieldStyle {
     public var isOptional: Bool = true
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var title: ElementStyle? = DefaultTitleLabelStyle(text: Constants.LocalizationKeys.BillingForm.AddressLine1.title)
     public var hint: ElementStyle?
     public var textfield: ElementTextFieldStyle = DefaultTextField()

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/City/DefaultBillingFormCityCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/City/DefaultBillingFormCityCellStyle.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public struct DefaultBillingFormCityCellStyle: CellTextFieldStyle {
     public var isOptional: Bool = false
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var title: ElementStyle? = DefaultTitleLabelStyle(text: Constants.LocalizationKeys.BillingForm.City.text)
     public var hint: ElementStyle?
     public var textfield: ElementTextFieldStyle = DefaultTextField()

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/FullName/DefaultBillingFormFullNameCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/FullName/DefaultBillingFormFullNameCellStyle.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public struct DefaultBillingFormFullNameCellStyle: CellTextFieldStyle {
     public var isOptional: Bool = false
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var title: ElementStyle? = DefaultTitleLabelStyle(text: Constants.LocalizationKeys.BillingForm.FullName.text)
     public var hint: ElementStyle?
     public var textfield: ElementTextFieldStyle = DefaultTextField()

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/PhoneNumber/DefaultBillingFormPhoneNumberCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/PhoneNumber/DefaultBillingFormPhoneNumberCellStyle.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public struct DefaultBillingFormPhoneNumberCellStyle: CellTextFieldStyle {
     public var isOptional: Bool = false
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var title: ElementStyle? = DefaultTitleLabelStyle(text: Constants.LocalizationKeys.BillingForm.PhoneNumber.text)
     public var hint: ElementStyle? = DefaultHintInputLabelStyle(isHidden: false, text: Constants.LocalizationKeys.BillingForm.PhoneNumber.hint)
     public var textfield: ElementTextFieldStyle = DefaultTextField(isSupportingNumericKeyboard: true)

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/Postcode/DefaultBillingFormPostCodeCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/Postcode/DefaultBillingFormPostCodeCellStyle.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public struct DefaultBillingFormPostcodeCellStyle: CellTextFieldStyle {
     public var isOptional: Bool = false
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var title: ElementStyle? = DefaultTitleLabelStyle(text: Constants.LocalizationKeys.BillingForm.Postcode.text)
     public var hint: ElementStyle?
     public var textfield: ElementTextFieldStyle = DefaultTextField()

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/State/DefaultBillingFormStateCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/State/DefaultBillingFormStateCellStyle.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public struct DefaultBillingFormStateCellStyle: CellTextFieldStyle {
     public var isOptional: Bool = false
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var title: ElementStyle? = DefaultTitleLabelStyle(text: Constants.LocalizationKeys.BillingForm.State.text)
     public var hint: ElementStyle?
     public var textfield: ElementTextFieldStyle = DefaultTextField()

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Header/Cancel/DefaultCancelButtonFormStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Header/Cancel/DefaultCancelButtonFormStyle.swift
@@ -8,7 +8,7 @@ public struct DefaultCancelButtonFormStyle: ElementButtonStyle {
     public var disabledTitleColor: UIColor = .doveGray
     public var disabledTintColor: UIColor = .doveGray
     public var activeTintColor: UIColor = .brandeisBlue
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var textColor: UIColor = .clear
     public var normalBorderColor: UIColor = .clear
     public var focusBorderColor: UIColor = .clear

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Header/Done/DefaultDoneFormButtonStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Header/Done/DefaultDoneFormButtonStyle.swift
@@ -8,7 +8,7 @@ public struct DefaultDoneFormButtonStyle: ElementButtonStyle {
     public var disabledTitleColor: UIColor = .doveGray
     public var disabledTintColor: UIColor = .doveGray
     public var activeTintColor: UIColor = .brandeisBlue
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var normalBorderColor: UIColor = .clear
     public var focusBorderColor: UIColor = .clear
     public var errorBorderColor: UIColor = .clear

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Header/Main/DefaultBillingFormHeaderCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Header/Main/DefaultBillingFormHeaderCellStyle.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public struct DefaultBillingFormHeaderCellStyle: BillingFormHeaderCellStyle {
 
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var headerLabel: ElementStyle = DefaultHeaderLabelFormStyle()
     public var cancelButton: ElementButtonStyle = DefaultCancelButtonFormStyle()
     public var doneButton: ElementButtonStyle = DefaultDoneFormButtonStyle()

--- a/Source/UI/NewUI/BillingForm/Default Implementation/Elements/Country/Country.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/Elements/Country/Country.swift
@@ -8,7 +8,7 @@ public class DefaultCountryFormButtonStyle: ElementButtonStyle {
     public var disabledTitleColor: UIColor = .mediumGray
     public var disabledTintColor: UIColor = .mediumGray
     public var activeTintColor: UIColor = .brandeisBlue
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var textColor: UIColor = .clear
     public var normalBorderColor: UIColor = .mediumGray
     public var focusBorderColor: UIColor = .brandeisBlue

--- a/Source/UI/NewUI/BillingForm/Default Implementation/Elements/Error/DefaultErrorInputLabelStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/Elements/Error/DefaultErrorInputLabelStyle.swift
@@ -3,7 +3,7 @@ import UIKit
 public struct DefaultErrorInputLabelStyle: ElementErrorViewStyle {
     public var isHidden: Bool = true
     public var isWarningImageOnLeft: Bool = true
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var tintColor: UIColor = .tallPoppyRed
     public var text: String = ""
     public var font: UIFont = UIFont(graphikStyle: .medium, size: Constants.Style.BillingForm.InputErrorLabel.fontSize.rawValue)

--- a/Source/UI/NewUI/BillingForm/Default Implementation/Elements/TextField/DefaultTextField.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/Elements/TextField/DefaultTextField.swift
@@ -10,7 +10,7 @@ public struct DefaultTextField: ElementTextFieldStyle {
     public var normalBorderColor: UIColor = .mediumGray
     public var focusBorderColor: UIColor = .brandeisBlue
     public var errorBorderColor: UIColor = .tallPoppyRed
-    public var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .clear
     public var tintColor: UIColor = .codGray
     public var width: Double = Constants.Style.BillingForm.InputTextField.width.rawValue
     public var height: Double = Constants.Style.BillingForm.InputTextField.height.rawValue

--- a/Source/UI/NewUI/BillingForm/View/BillingFormHeaderCell.swift
+++ b/Source/UI/NewUI/BillingForm/View/BillingFormHeaderCell.swift
@@ -27,7 +27,7 @@ final class BillingFormHeaderCell: UIView {
         let view = UILabel()
         view.numberOfLines = 0
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        view.backgroundColor = .clear
         return view
     }()
 

--- a/Source/UI/NewUI/BillingForm/View/BillingFormPhoneNumberText.swift
+++ b/Source/UI/NewUI/BillingForm/View/BillingFormPhoneNumberText.swift
@@ -41,6 +41,7 @@ final class BillingFormPhoneNumberText: BillingFormTextField {
     init(type: BillingFormCell?, tag: Int, phoneNumberTextDelegate: BillingFormPhoneNumberTextDelegate) {
         super.init(type: type, tag: tag)
         self.phoneNumberTextDelegate = phoneNumberTextDelegate
+        backgroundColor = .clear
         setup()
     }
 

--- a/Source/UI/NewUI/BillingForm/View/BillingFormTextField.swift
+++ b/Source/UI/NewUI/BillingForm/View/BillingFormTextField.swift
@@ -6,6 +6,7 @@ class BillingFormTextField: UITextField {
     init(type: BillingFormCell?, tag: Int) {
         self.type = type
         super.init(frame: .zero)
+        backgroundColor = .clear
         self.tag = tag
     }
 

--- a/Source/UI/NewUI/BillingForm/ViewController/BillingFormViewController.swift
+++ b/Source/UI/NewUI/BillingForm/ViewController/BillingFormViewController.swift
@@ -55,6 +55,7 @@ final class BillingFormViewController: UIViewController {
         view.showsHorizontalScrollIndicator = false
         view.allowsSelection = false
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .clear
         view.register(CellTextField.self)
         view.register(CellButton.self)
 

--- a/Source/UI/NewUI/CommonUI/View/ErrorView.swift
+++ b/Source/UI/NewUI/CommonUI/View/ErrorView.swift
@@ -7,7 +7,7 @@ final class ErrorView: UIView {
         view.textAlignment = .justified
         view.numberOfLines = 0
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        view.backgroundColor = .clear
         return view
     }()
 
@@ -15,7 +15,7 @@ final class ErrorView: UIView {
         let view = UIImageView()
         view.contentMode = .scaleAspectFit
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        view.backgroundColor = .clear
         return view
     }()
 

--- a/Source/UI/NewUI/CommonUI/View/SelectionButtonView.swift
+++ b/Source/UI/NewUI/CommonUI/View/SelectionButtonView.swift
@@ -14,7 +14,7 @@ class SelectionButtonView: UIView {
         let view = UILabel()
         view.numberOfLines = 0
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        view.backgroundColor = .clear
         return view
     }()
 
@@ -22,7 +22,7 @@ class SelectionButtonView: UIView {
         let view = UILabel()
         view.numberOfLines = 0
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        view.backgroundColor = .clear
         return view
     }()
 
@@ -30,7 +30,7 @@ class SelectionButtonView: UIView {
         let view = UIImageView()
         view.contentMode = .scaleAspectFit
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        view.backgroundColor = .clear
         return view
     }()
 

--- a/Source/UI/NewUI/CommonUI/View/TableViewCell/CellButton.swift
+++ b/Source/UI/NewUI/CommonUI/View/TableViewCell/CellButton.swift
@@ -18,6 +18,7 @@ final class CellButton: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        backgroundColor = .clear
         self.setupViewsInOrder()
     }
 

--- a/Source/UI/NewUI/CommonUI/View/TableViewCell/CellTextField.swift
+++ b/Source/UI/NewUI/CommonUI/View/TableViewCell/CellTextField.swift
@@ -22,6 +22,7 @@ final class CellTextField: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupViewsInOrder()
+        backgroundColor = .clear
     }
 
     func update(type: BillingFormCell?, style: CellTextFieldStyle?, tag: Int, textFieldValue: String?) {

--- a/Source/UI/NewUI/CommonUI/View/TextFieldView.swift
+++ b/Source/UI/NewUI/CommonUI/View/TextFieldView.swift
@@ -23,7 +23,7 @@ class TextFieldView: UIView {
         let view = UILabel()
         view.numberOfLines = 0
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        view.backgroundColor = .clear
         return view
     }()
 
@@ -31,7 +31,7 @@ class TextFieldView: UIView {
         let view = UILabel()
         view.numberOfLines = 0
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        view.backgroundColor = .clear
         return view
     }()
 
@@ -39,6 +39,7 @@ class TextFieldView: UIView {
         let view = UIView()
         view.layer.cornerRadius = 10.0
         view.layer.borderWidth = 1.0
+        view.backgroundColor = .clear
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -68,6 +69,7 @@ class TextFieldView: UIView {
         self.type = type
         self.style = style
         setupViewsInOrder()
+        backgroundColor = style.backgroundColor
         updateHeaderLabel(style: style)
         updateHintLabel(style: style)
         updateTextFieldContainer(style: style)

--- a/Tests/UI/New UI/BillingForm/View/BillingFormButtonViewTests.swift
+++ b/Tests/UI/New UI/BillingForm/View/BillingFormButtonViewTests.swift
@@ -29,12 +29,6 @@ class BillingFormButtonViewTests: XCTestCase {
         XCTAssertEqual(view.image?.tintColor, style.button.disabledTintColor)
     }
 
-    func testButtonStyle() {
-        XCTAssertEqual(view.button?.isEnabled, style.button.isEnabled)
-        XCTAssertEqual(view.button?.tintColor, .clear)
-        XCTAssertEqual(view.button?.backgroundColor, .clear)
-    }
-
     func testErrorStyle() {
         XCTAssertEqual(view.errorView?.isHidden, style.error.isHidden)
     }


### PR DESCRIPTION
[Jira Ticket ](https://checkout.atlassian.net/browse/PIMOB-1240)

## Proposed changes

Change the background colour of the whole page
Be able to change the background colour of the whole billing form page in one go,  ( Currently  BillingFormStyle’s mainBackground only changes a part of the background as the table view, cells, components background overlaps and does not allow to change the background, By default the table view, cells, components background opacity should be 0. If a merchant wishes to change this should be able to change it via individual components which overrides the mainBackground color of BillingFormStyle.

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
