### PR TITLE
PIMOB-1240: Fix billing form cells order

### DIFF
--- a/Source/Resources/en.lproj/Localizable.strings
+++ b/Source/Resources/en.lproj/Localizable.strings
@@ -28,14 +28,11 @@
 "postalTown" = "Town";
 "postcode" = "Postcode";
 "phone" = "Phone";
-
 "acceptedCards" = "Accepted Cards";
-
 "cardNumberInvalid" = "The card number is invalid";
 "cardTypeNotAccepted" = "The card type is not accepted";
 "cvvInvalid" = "The cvv is invalid";
 "expiryDateInvalid" = "The Expiry Date is invalid";
 "phoneNumberInvalid" = "Invalid, use country code (e.g. +44)";
-
 "cardViewControllerTitle" = "Payment";
 "addressViewControllerTitle" = "Billing";

--- a/Source/UI/Controllers/AddressViewController.swift
+++ b/Source/UI/Controllers/AddressViewController.swift
@@ -181,8 +181,8 @@ public class AddressViewController: UIViewController,
 
     // MARK: - CountrySelectionViewControllerDelegate
 
-    /// Executed when an user select a country.
-    public func onCountrySelected(country: Country) {
+    /// Executed when a user select a country.
+    public func onCountrySelected(country: Country, tag: Int) {
         setCountrySelected(country: country)
     }
 

--- a/Source/UI/Controllers/AddressViewController.swift
+++ b/Source/UI/Controllers/AddressViewController.swift
@@ -182,7 +182,7 @@ public class AddressViewController: UIViewController,
     // MARK: - CountrySelectionViewControllerDelegate
 
     /// Executed when a user select a country.
-    public func onCountrySelected(country: Country, tag: Int) {
+    public func onCountrySelected(country: Country) {
         setCountrySelected(country: country)
     }
 

--- a/Source/UI/Controllers/CountrySelectionViewController.swift
+++ b/Source/UI/Controllers/CountrySelectionViewController.swift
@@ -98,7 +98,7 @@ public class CountrySelectionViewController: UIViewController,
     /// Tells the delegate that the specified row is now selected.
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let country = Country(iso3166Alpha2: filteredCountries[indexPath.row].1, dialingCode: nil)
-        delegate?.onCountrySelected(country: country)
+        delegate?.onCountrySelected(country: country, tag: view.tag)
         navigationController?.popViewController(animated: true)
     }
 

--- a/Source/UI/Controllers/CountrySelectionViewController.swift
+++ b/Source/UI/Controllers/CountrySelectionViewController.swift
@@ -98,7 +98,7 @@ public class CountrySelectionViewController: UIViewController,
     /// Tells the delegate that the specified row is now selected.
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let country = Country(iso3166Alpha2: filteredCountries[indexPath.row].1, dialingCode: nil)
-        delegate?.onCountrySelected(country: country, tag: view.tag)
+        delegate?.onCountrySelected(country: country)
         navigationController?.popViewController(animated: true)
     }
 

--- a/Source/UI/Delegates/CountrySelectionViewControllerDelegate.swift
+++ b/Source/UI/Delegates/CountrySelectionViewControllerDelegate.swift
@@ -7,5 +7,5 @@ public protocol CountrySelectionViewControllerDelegate: AnyObject {
     ///
     /// - parameter country: Country selected
     /// - parameter regionCode: Region code of the selected country
-    func onCountrySelected(country: Country)
+    func onCountrySelected(country: Country, tag: Int)
 }

--- a/Source/UI/Delegates/CountrySelectionViewControllerDelegate.swift
+++ b/Source/UI/Delegates/CountrySelectionViewControllerDelegate.swift
@@ -6,6 +6,5 @@ public protocol CountrySelectionViewControllerDelegate: AnyObject {
     /// Executed when an user select a country
     ///
     /// - parameter country: Country selected
-    /// - parameter regionCode: Region code of the selected country
-    func onCountrySelected(country: Country, tag: Int)
+    func onCountrySelected(country: Country)
 }

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/AddressLine1/DefaultBillingFormAddressLine1CellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/AddressLine1/DefaultBillingFormAddressLine1CellStyle.swift
@@ -6,5 +6,5 @@ public struct DefaultBillingFormAddressLine1CellStyle : CellTextFieldStyle {
     public var title: ElementStyle? = DefaultTitleLabelStyle(text:  Constants.LocalizationKeys.BillingForm.AddressLine1.title)
     public var hint: ElementStyle?
     public var textfield: ElementTextFieldStyle = DefaultTextField()
-    public var error: ElementErrorViewStyle = DefaultErrorInputLabelStyle(text:  Constants.LocalizationKeys.BillingForm.AddressLine1.error)
+    public var error: ElementErrorViewStyle? = DefaultErrorInputLabelStyle(text:  Constants.LocalizationKeys.BillingForm.AddressLine1.error)
 }

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/AddressLine2/DefaultBillingFormAddressLine2CellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/AddressLine2/DefaultBillingFormAddressLine2CellStyle.swift
@@ -6,5 +6,5 @@ public struct DefaultBillingFormAddressLine2CellStyle : CellTextFieldStyle {
     public var title: ElementStyle? = DefaultTitleLabelStyle(text:  Constants.LocalizationKeys.BillingForm.AddressLine2.title)
     public var hint: ElementStyle? = nil
     public var textfield: ElementTextFieldStyle = DefaultTextField()
-    public var error: ElementErrorViewStyle = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.AddressLine2.error)
+    public var error: ElementErrorViewStyle? = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.AddressLine2.error)
 }

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/City/DefaultBillingFormCityCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/City/DefaultBillingFormCityCellStyle.swift
@@ -6,5 +6,5 @@ public struct DefaultBillingFormCityCellStyle : CellTextFieldStyle {
     public var title: ElementStyle? = DefaultTitleLabelStyle(text:  Constants.LocalizationKeys.BillingForm.City.text)
     public var hint: ElementStyle?
     public var textfield: ElementTextFieldStyle = DefaultTextField()
-    public var error: ElementErrorViewStyle = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.City.error)
+    public var error: ElementErrorViewStyle? = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.City.error)
 }

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/Country/DefaultBillingFormCountryCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/Country/DefaultBillingFormCountryCellStyle.swift
@@ -5,6 +5,6 @@ public struct DefaultBillingFormCountryCellStyle: CellButtonStyle {
     public var button: ElementButtonStyle = DefaultCountryFormButtonStyle()
     public var isMandatory: Bool = true
     public var title: ElementStyle? = DefaultTitleLabelStyle(text: Constants.LocalizationKeys.BillingForm.Country.text, textColor: .doveGray)
-    public var hint: ElementStyle? = nil
-    public var error: ElementErrorViewStyle = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.Country.error)
+    public var hint: ElementStyle?
+    public var error: ElementErrorViewStyle?
 }

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/FullName/DefaultBillingFormFullNameCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/FullName/DefaultBillingFormFullNameCellStyle.swift
@@ -6,5 +6,5 @@ public struct DefaultBillingFormFullNameCellStyle : CellTextFieldStyle {
     public var title: ElementStyle? = DefaultTitleLabelStyle(text:  Constants.LocalizationKeys.BillingForm.FullName.text)
     public var hint: ElementStyle?
     public var textfield: ElementTextFieldStyle = DefaultTextField()
-    public var error: ElementErrorViewStyle = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.FullName.error)
+    public var error: ElementErrorViewStyle? = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.FullName.error)
 }

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/PhoneNumber/DefaultBillingFormPhoneNumberCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/PhoneNumber/DefaultBillingFormPhoneNumberCellStyle.swift
@@ -6,6 +6,6 @@ public struct DefaultBillingFormPhoneNumberCellStyle : CellTextFieldStyle {
     public var title: ElementStyle? = DefaultTitleLabelStyle(text:  Constants.LocalizationKeys.BillingForm.PhoneNumber.text)
     public var hint: ElementStyle? = DefaultHintInputLabelStyle(isHidden: false, text:  Constants.LocalizationKeys.BillingForm.PhoneNumber.hint)
     public var textfield: ElementTextFieldStyle = DefaultTextField(isSupportingNumericKeyboard: true)
-    public var error: ElementErrorViewStyle = DefaultErrorInputLabelStyle(text:  Constants.LocalizationKeys.BillingForm.PhoneNumber.error)
+    public var error: ElementErrorViewStyle? = DefaultErrorInputLabelStyle(text:  Constants.LocalizationKeys.BillingForm.PhoneNumber.error)
     
 }

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/Postcode/DefaultBillingFormPostCodeCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/Postcode/DefaultBillingFormPostCodeCellStyle.swift
@@ -6,5 +6,5 @@ public struct DefaultBillingFormPostcodeCellStyle : CellTextFieldStyle {
     public var title: ElementStyle? = DefaultTitleLabelStyle(text:  Constants.LocalizationKeys.BillingForm.Postcode.text)
     public var hint: ElementStyle?
     public var textfield: ElementTextFieldStyle = DefaultTextField()
-    public var error: ElementErrorViewStyle = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.Postcode.error)
+    public var error: ElementErrorViewStyle? = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.Postcode.error)
 }

--- a/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/State/DefaultBillingFormStateCellStyle.swift
+++ b/Source/UI/NewUI/BillingForm/Default Implementation/BillingForm/Fields/State/DefaultBillingFormStateCellStyle.swift
@@ -6,5 +6,5 @@ public struct DefaultBillingFormStateCellStyle : CellTextFieldStyle {
     public var title: ElementStyle? = DefaultTitleLabelStyle(text:  Constants.LocalizationKeys.BillingForm.State.text)
     public var hint: ElementStyle?
     public var textfield: ElementTextFieldStyle = DefaultTextField()
-    public var error: ElementErrorViewStyle = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.State.error)
+    public var error: ElementErrorViewStyle? = DefaultErrorInputLabelStyle(text: Constants.LocalizationKeys.BillingForm.State.error)
 }

--- a/Source/UI/NewUI/BillingForm/View/BillingFormPhoneNumberText.swift
+++ b/Source/UI/NewUI/BillingForm/View/BillingFormPhoneNumberText.swift
@@ -3,7 +3,7 @@ import UIKit
 import PhoneNumberKit
 
 protocol BillingFormPhoneNumberTextDelegate {
-    func phoneNumberIsUpdated(number: String)
+    func phoneNumberIsUpdated(number: String, tag: Int)
 }
 
 // `PhoneNumberTextField` is the parent textfield from `PhoneNumberKit`
@@ -29,6 +29,6 @@ final class BillingFormPhoneNumberText: PhoneNumberTextField, BillingFormTextFie
     override func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
         super.textFieldDidEndEditing(textField, reason: reason)
         guard let phoneNumber = text else { return }
-        phoneNumberTextDelegate?.phoneNumberIsUpdated(number: phoneNumber)
+        phoneNumberTextDelegate?.phoneNumberIsUpdated(number: phoneNumber, tag: tag)
     }
 }

--- a/Source/UI/NewUI/BillingForm/ViewController/BillingFormViewController.swift
+++ b/Source/UI/NewUI/BillingForm/ViewController/BillingFormViewController.swift
@@ -17,7 +17,7 @@ protocol BillingFormViewControllerDelegate: AnyObject {
     func doneButtonIsPressed(sender: UIViewController)
     func cancelButtonIsPressed(sender: UIViewController)
     func getViewForHeader(sender: UIViewController) -> UIView?
-    func update(country: Country)
+    func update(country: Country, tag: Int)
 }
 
 /**
@@ -243,15 +243,16 @@ extension BillingFormViewController: BillingFormHeaderCellDelegate {
 }
 
 extension BillingFormViewController: CellButtonDelegate {
-    func buttonIsPressed() {
+    func buttonIsPressed(tag: Int) {
         let countryViewController = CountrySelectionViewController()
         countryViewController.delegate = self
+        countryViewController.view.tag = tag
         navigationController?.pushViewController(countryViewController, animated: true)
     }
 }
 
 extension BillingFormViewController: CountrySelectionViewControllerDelegate {
-    func onCountrySelected(country: Country) {
-        delegate?.update(country: country)
+    func onCountrySelected(country: Country, tag: Int) {
+        delegate?.update(country: country, tag: tag)
     }
 }

--- a/Source/UI/NewUI/BillingForm/ViewController/BillingFormViewController.swift
+++ b/Source/UI/NewUI/BillingForm/ViewController/BillingFormViewController.swift
@@ -17,8 +17,8 @@ protocol BillingFormViewControllerDelegate: AnyObject {
     func doneButtonIsPressed(sender: UIViewController)
     func cancelButtonIsPressed(sender: UIViewController)
     func getViewForHeader(sender: UIViewController) -> UIView?
-    func update(country: Country, tag: Int)
-    func phoneNumberIsUpdated(number: String)
+    func update(country: Country)
+    func phoneNumberIsUpdated(number: String, tag: Int)
 }
 
 /**
@@ -211,8 +211,8 @@ extension BillingFormViewController: UITableViewDataSource, UITableViewDelegate 
 // MARK: - Text Field Delegate
 
 extension BillingFormViewController: CellTextFieldDelegate {
-    func phoneNumberIsUpdated(number: String) {
-        delegate?.phoneNumberIsUpdated(number: number)
+    func phoneNumberIsUpdated(number: String, tag: Int) {
+        delegate?.phoneNumberIsUpdated(number: number, tag: tag)
     }
 
     func textFieldShouldChangeCharactersIn(textField: UITextField, replacementString string: String) {
@@ -257,7 +257,7 @@ extension BillingFormViewController: CellButtonDelegate {
 }
 
 extension BillingFormViewController: CountrySelectionViewControllerDelegate {
-    func onCountrySelected(country: Country, tag: Int) {
-        delegate?.update(country: country, tag: tag)
+    func onCountrySelected(country: Country) {
+        delegate?.update(country: country)
     }
 }

--- a/Source/UI/NewUI/BillingForm/ViewModel/DefaultBillingFormViewModel.swift
+++ b/Source/UI/NewUI/BillingForm/ViewModel/DefaultBillingFormViewModel.swift
@@ -19,12 +19,13 @@ final class DefaultBillingFormViewModel: BillingFormViewModel {
     var textValueOfCellType = [Int: String]()
 
     private var country : Country?
+    private var countryRow: Int?
     private(set) var style: BillingFormStyle
     private(set) var data: BillingForm?
     private(set) var updatedRow: Int? {
         didSet { updateRow?() }
     }
-
+    
     // MARK: - Public methods
     
     /**
@@ -55,6 +56,7 @@ final class DefaultBillingFormViewModel: BillingFormViewModel {
         guard style.cells.count > indexPath.row else { return UITableViewCell() }
         
         if isCountryType(for: indexPath.row) {
+            countryRow = indexPath.row
             return getCountryCell(tableView: tableView, indexPath: indexPath, sender: sender)
         }
         return getTextFieldCell(tableView: tableView, indexPath: indexPath, sender: sender)
@@ -68,7 +70,7 @@ final class DefaultBillingFormViewModel: BillingFormViewModel {
             let isMandatory = type.style?.isMandatory ?? true
             let value = type.getText(from: data)
             let hasValue = value != nil
-
+            country = data?.address.country
             textValueOfCellType[type.index] = hasValue ? value : (!isMandatory ? "" : nil)
             errorFlagOfCellType[type.index] = hasValue ? false : isMandatory
         }
@@ -98,7 +100,6 @@ final class DefaultBillingFormViewModel: BillingFormViewModel {
     /// country selection button
     private func getCountryCell(tableView: UITableView, indexPath: IndexPath, sender: UIViewController?) -> UITableViewCell {
 
-        /// table view cell
         if let cell: CellButton = tableView.dequeueReusable(for: indexPath) {
             let cellStyle = updateCountrySelectionStyle(for: indexPath.row)
             cell.delegate = sender as? CellButtonDelegate
@@ -149,20 +150,22 @@ final class DefaultBillingFormViewModel: BillingFormViewModel {
     func validateTextFieldByCharacter(textField: UITextField, replacementString string: String) {
         guard let type = (textField as? BillingFormTextField)?.type else { return }
         
-        validate(text: string, cellStyle: type, row: textField.tag)
+        validate(text: textField.text, cellStyle: type, row: textField.tag)
         
-        let shouldRemoveText = (textField.text?.count ?? 1 == 1) && (type.style?.isMandatory ?? false)
-        
-        if !string.isEmpty {
-            textValueOfCellType[type.index] = string
-        } else if shouldRemoveText {
+        let isEmptyText = textField.text?.isEmpty ?? true
+        let isMandatoryField = type.style?.isMandatory ?? false
+        let shouldRemoveText = isEmptyText && isMandatoryField
+        let hasErrorValue = errorFlagOfCellType.isEmpty || errorFlagOfCellType.values.allSatisfy({$0})
+
+        if !isEmptyText {
+            textValueOfCellType[type.index] = textField.text
+        }
+
+        if shouldRemoveText {
             textValueOfCellType[type.index] = nil
         }
         
-        let hasErrorValue = errorFlagOfCellType.isEmpty || errorFlagOfCellType.values.allSatisfy({$0})
-        
         let areAllFieldsAreFulfilled = textValueOfCellType.values.count == style.cells.count && !hasErrorValue
-        
         editDelegate?.didFinishEditingBillingForm(successfully:  areAllFieldsAreFulfilled)
     }
     
@@ -171,7 +174,7 @@ final class DefaultBillingFormViewModel: BillingFormViewModel {
 
         validate(text: textField.text , cellStyle: type, row: textField.tag)
         
-        let shouldSaveText = !(textField.text?.isEmpty ?? true) || (type.style?.isMandatory ?? true)
+        let shouldSaveText = !(textField.text?.isEmpty ?? true)
         
         textValueOfCellType[type.index] =  shouldSaveText ? textField.text : nil
 
@@ -214,17 +217,17 @@ extension DefaultBillingFormViewModel: BillingFormTextFieldDelegate {
 // MARK: - Billing form view controller Delegate
 
 extension DefaultBillingFormViewModel: BillingFormViewControllerDelegate {
-    func phoneNumberIsUpdated(number: String) {
+    func phoneNumberIsUpdated(number: String, tag: Int) {
         let index = BillingFormCell.phoneNumber(nil).index
         textValueOfCellType[index] = number
-        updatedRow = index
+        updatedRow = tag
     }
 
-    func update(country: Country, tag: Int) {
+    func update(country: Country) {
         self.country = country
         let index = BillingFormCell.country(nil).index
         textValueOfCellType[index] = country.name
-        updatedRow = tag
+        updatedRow = countryRow
     }
     
     func getViewForHeader(sender: UIViewController) -> UIView? {

--- a/Source/UI/NewUI/BillingForm/ViewModel/DefaultBillingFormViewModel.swift
+++ b/Source/UI/NewUI/BillingForm/ViewModel/DefaultBillingFormViewModel.swift
@@ -77,7 +77,9 @@ final class DefaultBillingFormViewModel: BillingFormViewModel {
     }
 
     private func isCountryType(for row: Int) -> Bool {
-        style.cells[row].index == BillingFormCell.country(.none).index
+        let currentCellType = style.cells[row]
+        let countryType = BillingFormCell.country(nil)
+        return currentCellType.index == countryType.index
     }
 
     private func getTextFieldCell(tableView: UITableView, indexPath: IndexPath, sender: UIViewController?) -> UITableViewCell {
@@ -114,35 +116,35 @@ final class DefaultBillingFormViewModel: BillingFormViewModel {
     /// update text fields with pre-filled text
     private func updateTextFieldStyle(for row: Int) -> CellTextFieldStyle? {
         var viewStyle = style.cells[row].style as? CellTextFieldStyle
-        if let text = textValueOfCellType[row] {
+        let currentCellTypeIndex = style.cells[row].index
+        if let text = textValueOfCellType[currentCellTypeIndex] {
             viewStyle?.textfield.text = text
         }
-        viewStyle?.error.isHidden = !(errorFlagOfCellType[row] ?? false)
+        viewStyle?.error?.isHidden = !(errorFlagOfCellType[currentCellTypeIndex] ?? false)
         return viewStyle
     }
 
     /// update country selection with pre-filled text
     private func updateCountrySelectionStyle(for row: Int) -> CellButtonStyle? {
         var viewStyle = style.cells[row].style as? CellButtonStyle
-        if let text = textValueOfCellType[row] {
+        let currentCellTypeIndex = style.cells[row].index
+        if let text = textValueOfCellType[currentCellTypeIndex] {
             viewStyle?.button.text = text
         }
-        viewStyle?.error.isHidden = !(errorFlagOfCellType[row] ?? false)
+        viewStyle?.error?.isHidden = !(errorFlagOfCellType[currentCellTypeIndex] ?? false)
         return viewStyle
     }
 
     // MARK: - Text Field logic
 
     func validate(text: String?, cellStyle: BillingFormCell, row: Int) {
-
-        guard cellStyle.index < errorFlagOfCellType.count,
-              cellStyle.index >= 0,
-              let style = cellStyle.style,
+        let currentCellTypeIndex = style.cells[row].index
+        guard let style = cellStyle.style,
               style.isMandatory else {
-            errorFlagOfCellType[cellStyle.index] = false
+            errorFlagOfCellType[currentCellTypeIndex] = false
             return
         }
-        errorFlagOfCellType[cellStyle.index] = cellStyle.validator.validate(text: text)
+        errorFlagOfCellType[currentCellTypeIndex] = cellStyle.validator.validate(text: text)
     }
 
     func validateTextFieldByCharacter(textField: UITextField, replacementString string: String) {
@@ -174,7 +176,7 @@ final class DefaultBillingFormViewModel: BillingFormViewModel {
         
         textValueOfCellType[type.index] =  shouldSaveText ? textField.text : nil
 
-        updatedRow = textField.type?.index
+        updatedRow = textField.tag
     }
 }
 
@@ -214,11 +216,11 @@ extension DefaultBillingFormViewModel: BillingFormTextFieldDelegate {
 
 extension DefaultBillingFormViewModel: BillingFormViewControllerDelegate {
 
-    func update(country: Country) {
+    func update(country: Country, tag: Int) {
         self.country = country
         let index = BillingFormCell.country(nil).index
         textValueOfCellType[index] = country.name
-        updatedRow = index
+        updatedRow = tag
     }
 
     func getViewForHeader(sender: UIViewController) -> UIView? {

--- a/Source/UI/NewUI/CommonUI/Protocols/Cell/CellStyle.swift
+++ b/Source/UI/NewUI/CommonUI/Protocols/Cell/CellStyle.swift
@@ -5,5 +5,5 @@ public protocol CellStyle {
     var backgroundColor: UIColor { get }
     var title: ElementStyle? { get }
     var hint: ElementStyle? { get }
-    var error: ElementErrorViewStyle { get set }
+    var error: ElementErrorViewStyle? { get set }
 }

--- a/Source/UI/NewUI/CommonUI/View/SelectionButtonView.swift
+++ b/Source/UI/NewUI/CommonUI/View/SelectionButtonView.swift
@@ -59,8 +59,6 @@ class SelectionButtonView: UIView {
         self.type = type
         self.style = style
 
-
-
         /// title label style
         titleLabel?.text = style.title?.text
         titleLabel?.font = style.title?.font

--- a/Source/UI/NewUI/CommonUI/View/SelectionButtonView.swift
+++ b/Source/UI/NewUI/CommonUI/View/SelectionButtonView.swift
@@ -97,7 +97,7 @@ class SelectionButtonView: UIView {
 
     private func updateErrorView(style: CellButtonStyle) {
         errorView?.update(style: style.error)
-        errorView?.isHidden = style.error.isHidden
+        errorView?.isHidden = style.error?.isHidden ?? true
     }
 }
 

--- a/Source/UI/NewUI/CommonUI/View/TableViewCell/CellButton.swift
+++ b/Source/UI/NewUI/CommonUI/View/TableViewCell/CellButton.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 protocol CellButtonDelegate: AnyObject {
-    func buttonIsPressed()
+    func buttonIsPressed(tag: Int)
 }
 // TODO: This is unfinished work. it will be finished in the Country selection ticket.
 final class CellButton: UITableViewCell {
@@ -56,6 +56,6 @@ extension CellButton {
 
 extension CellButton: SelectionButtonViewDelegate {
     func buttonIsPressed() {
-        delegate?.buttonIsPressed()
+        delegate?.buttonIsPressed(tag: tag)
     }
 }

--- a/Source/UI/NewUI/CommonUI/View/TableViewCell/CellTextField.swift
+++ b/Source/UI/NewUI/CommonUI/View/TableViewCell/CellTextField.swift
@@ -2,7 +2,7 @@ import UIKit
 import Checkout
 
 protocol CellTextFieldDelegate: AnyObject {
-    func phoneNumberIsUpdated(number: String)
+    func phoneNumberIsUpdated(number: String, tag: Int)
     func textFieldShouldBeginEditing(textField: UITextField)
     func textFieldShouldReturn()
     func textFieldShouldEndEditing(textField: UITextField, replacementString: String)
@@ -62,8 +62,8 @@ extension CellTextField {
 }
 
 extension CellTextField: TextFieldViewDelegate {
-    func phoneNumberIsUpdated(number: String) {
-        delegate?.phoneNumberIsUpdated(number: number)
+    func phoneNumberIsUpdated(number: String, tag: Int) {
+        delegate?.phoneNumberIsUpdated(number: number, tag: tag)
     }
     
     func textFieldShouldChangeCharactersIn(textField: UITextField, replacementString string: String) {

--- a/Source/UI/NewUI/CommonUI/View/TableViewCell/CellTextField.swift
+++ b/Source/UI/NewUI/CommonUI/View/TableViewCell/CellTextField.swift
@@ -29,7 +29,7 @@ final class CellTextField: UITableViewCell {
         self.type = type
         self.style = style
         self.tag = tag
-        mainView?.update(style: style, type: type, textFieldValue: textFieldValue)
+        mainView?.update(style: style, type: type, textFieldValue: textFieldValue, tag: tag)
     }
 
     @available(*, unavailable)

--- a/Source/UI/NewUI/CommonUI/View/TextFieldView.swift
+++ b/Source/UI/NewUI/CommonUI/View/TextFieldView.swift
@@ -70,7 +70,7 @@ class TextFieldView: UIView {
 
     // MARK: - Update subviews style
 
-    func update(style: CellStyle?, type: BillingFormCell?, textFieldValue: String? = nil) {
+    func update(style: CellStyle?, type: BillingFormCell?, textFieldValue: String? = nil, tag: Int) {
         guard let type = type, let style = style as? CellTextFieldStyle else { return }
         self.type = type
         self.style = style
@@ -80,7 +80,7 @@ class TextFieldView: UIView {
         setupMandatoryLabel(style: style)
         updateHintLabel(style: style)
         updateTextFieldContainer(style: style)
-        updateTextField(style: style, textFieldValue: textFieldValue)
+        updateTextField(style: style, textFieldValue: textFieldValue, tag: tag)
         updateErrorView(style: style)
     }
 
@@ -104,7 +104,7 @@ class TextFieldView: UIView {
     }
 
     private func updateTextFieldContainer(style: CellTextFieldStyle) {
-        let borderColor = !style.error.isHidden ?
+        let borderColor = !(style.error?.isHidden ?? true) ?
         style.textfield.errorBorderColor.cgColor :
         style.textfield.normalBorderColor.cgColor
 
@@ -114,11 +114,12 @@ class TextFieldView: UIView {
         textFieldContainer?.backgroundColor = style.textfield.backgroundColor
     }
 
-    private func updateTextField(style: CellTextFieldStyle, textFieldValue: String?) {
+    private func updateTextField(style: CellTextFieldStyle, textFieldValue: String?, tag: Int) {
         if let textFieldValue = textFieldValue {
             textField?.text = textFieldValue
         }
         textField?.type = type
+        textField?.tag = tag
         textField?.keyboardType = style.textfield.isSupportingNumericKeyboard ? .phonePad : .default
         textField?.textContentType = style.textfield.isSupportingNumericKeyboard ? .telephoneNumber : .name
         textField?.text = style.textfield.text
@@ -130,8 +131,10 @@ class TextFieldView: UIView {
 
     private func updateErrorView(style: CellTextFieldStyle) {
         errorView?.update(style: style.error)
-        errorView?.isHidden = style.error.isHidden
-        textFieldContainerBottomAnchor?.constant = -(style.error.isHidden ? 0 : style.error.height)
+        let shouldHideErrorView = style.error?.isHidden ?? false
+        let expectedErrorViewHeight = style.error?.height ?? 0
+        errorView?.isHidden = shouldHideErrorView
+        textFieldContainerBottomAnchor?.constant = -(shouldHideErrorView ? 0 : expectedErrorViewHeight)
     }
 }
 

--- a/Source/UI/NewUI/CommonUI/View/TextFieldView.swift
+++ b/Source/UI/NewUI/CommonUI/View/TextFieldView.swift
@@ -2,7 +2,7 @@ import UIKit
 import Checkout
 
 protocol TextFieldViewDelegate: AnyObject {
-    func phoneNumberIsUpdated(number: String)
+    func phoneNumberIsUpdated(number: String, tag: Int)
     func textFieldShouldBeginEditing(textField: UITextField)
     func textFieldShouldReturn()
     func textFieldShouldEndEditing(textField: UITextField, replacementString: String)
@@ -52,18 +52,23 @@ class TextFieldView: UIView {
         return view
     }()
     
-    private(set) lazy var textField: UITextField? = {
+    private(set) lazy var textField: BillingFormTextField? = {
         var view: BillingFormTextField  = DefaultBillingFormTextField(type: type, tag: tag)
         if self.type?.index == BillingFormCell.phoneNumber(nil).index {
             view = BillingFormPhoneNumberText(type: type, tag: tag, phoneNumberTextDelegate: self)
         }
+        view.addTarget(self, action: #selector(textFieldEditingChanged), for: .editingChanged)
         view.autocorrectionType = .no
         view.delegate = self
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .clear
         return  view
     }()
-    
+
+    @objc private func textFieldEditingChanged(textField: UITextField) {
+        delegate?.textFieldShouldChangeCharactersIn(textField: textField, replacementString: "")
+    }
+
     private(set) lazy var errorView: ErrorView? = {
         let view = ErrorView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -246,17 +251,12 @@ extension TextFieldView: UITextFieldDelegate {
         return false
     }
     
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        delegate?.textFieldShouldChangeCharactersIn(textField: textField, replacementString: string)
-        return true
-    }
-    
 }
 
 // MARK: - Phone Number Text Delegate
 
 extension TextFieldView: BillingFormPhoneNumberTextDelegate {
-    func phoneNumberIsUpdated(number: String) {
-        delegate?.phoneNumberIsUpdated(number: number)
+    func phoneNumberIsUpdated(number: String, tag: Int) {
+        delegate?.phoneNumberIsUpdated(number: number, tag: tag)
     }
 }

--- a/Tests/Mocks/BillingFormTextFieldCellMockDelegate.swift
+++ b/Tests/Mocks/BillingFormTextFieldCellMockDelegate.swift
@@ -14,7 +14,8 @@ class BillingFormTextFieldCellMockDelegate: CellTextFieldDelegate {
 
     var phoneNumberIsUpdatedCalledTimes = 0
     var phoneNumberIsUpdatedLastCalledWithNumber: String?
-    
+    var phoneNumberIsUpdatedLastCalledWithTag: Int?
+
     var textFieldShouldChangeCharactersInCalledTimes = 0
     var textFieldShouldChangeCharactersInLastCalledWithTextField: UITextField?
     var textFieldShouldChangeCharactersInLastCalledWithString: String?
@@ -35,9 +36,10 @@ class BillingFormTextFieldCellMockDelegate: CellTextFieldDelegate {
     }
     
 
-    func phoneNumberIsUpdated(number: String) {
+    func phoneNumberIsUpdated(number: String, tag: Int) {
         phoneNumberIsUpdatedCalledTimes += 1
         phoneNumberIsUpdatedLastCalledWithNumber = number
+        phoneNumberIsUpdatedLastCalledWithTag = tag
     }
     
     func textFieldShouldChangeCharactersIn(textField: UITextField, replacementString string: String) {

--- a/Tests/Mocks/BillingFormViewControllerMockDelegate.swift
+++ b/Tests/Mocks/BillingFormViewControllerMockDelegate.swift
@@ -33,12 +33,11 @@ class BillingFormViewControllerMockDelegate: BillingFormViewControllerDelegate {
 
     var updateCalledTimes = 0
     var updateLastCalledWithCountry: Country?
-    var updateLastCalledWithTag: Int?
-
 
     var phoneNumberIsUpdatedCalledTimes = 0
     var phoneNumberIsUpdatedLastCalledWithNumber: String?
-    
+    var phoneNumberIsUpdatedLastCalledWithTag: Int?
+
     func doneButtonIsPressed(sender: UIViewController) {
         doneButtonIsPressedCalledTimes += 1
         doneButtonIsPressedLastCalledWithSender = sender
@@ -84,14 +83,14 @@ class BillingFormViewControllerMockDelegate: BillingFormViewControllerDelegate {
         textFieldShouldChangeCharactersInLastCalledWithString = string
     }
 
-    func update(country: Country, tag: Int) {
+    func update(country: Country) {
         updateCalledTimes += 1
         updateLastCalledWithCountry = country
-        updateLastCalledWithTag = tag
     }
 
-    func phoneNumberIsUpdated(number: String) {
+    func phoneNumberIsUpdated(number: String, tag: Int) {
         phoneNumberIsUpdatedCalledTimes += 1
         phoneNumberIsUpdatedLastCalledWithNumber = number
+        phoneNumberIsUpdatedLastCalledWithTag = tag
     }
 }

--- a/Tests/Mocks/BillingFormViewControllerMockDelegate.swift
+++ b/Tests/Mocks/BillingFormViewControllerMockDelegate.swift
@@ -33,6 +33,7 @@ class BillingFormViewControllerMockDelegate: BillingFormViewControllerDelegate {
 
     var updateCalledTimes = 0
     var updateLastCalledWithCountry: Country?
+    var updateLastCalledWithTag: Int?
 
     func doneButtonIsPressed(sender: UIViewController) {
         doneButtonIsPressedCalledTimes += 1
@@ -79,8 +80,9 @@ class BillingFormViewControllerMockDelegate: BillingFormViewControllerDelegate {
         textFieldShouldChangeCharactersInLastCalledWithString = string
     }
 
-    func update(country: Country) {
+    func update(country: Country, tag: Int) {
         updateCalledTimes += 1
         updateLastCalledWithCountry = country
+        updateLastCalledWithTag = tag
     }
 }

--- a/Tests/UI/AddressViewControllerTests.swift
+++ b/Tests/UI/AddressViewControllerTests.swift
@@ -151,7 +151,7 @@ class AddressViewControllerTests: XCTestCase {
 
     func testSetCountryOnCountrySelected() {
         let country = Country(iso3166Alpha2: "FR", dialingCode: "")
-        addressViewController.onCountrySelected(country: country)
+        addressViewController.onCountrySelected(country: country, tag: 0)
         XCTAssertEqual(addressViewController.regionCodeSelected, country.iso3166Alpha2)
         XCTAssertEqual(addressViewController.addressView.countryRegionInputView.value.text, country.name)
     }

--- a/Tests/UI/AddressViewControllerTests.swift
+++ b/Tests/UI/AddressViewControllerTests.swift
@@ -151,7 +151,7 @@ class AddressViewControllerTests: XCTestCase {
 
     func testSetCountryOnCountrySelected() {
         let country = Country(iso3166Alpha2: "FR", dialingCode: "")
-        addressViewController.onCountrySelected(country: country, tag: 0)
+        addressViewController.onCountrySelected(country: country)
         XCTAssertEqual(addressViewController.regionCodeSelected, country.iso3166Alpha2)
         XCTAssertEqual(addressViewController.addressView.countryRegionInputView.value.text, country.name)
     }

--- a/Tests/UI/CountrySelectionViewControllerTests.swift
+++ b/Tests/UI/CountrySelectionViewControllerTests.swift
@@ -5,12 +5,10 @@ import Checkout
 class MockDelegate: CountrySelectionViewControllerDelegate {
     public var methodCalledTimes = 0
     public var methodLastCalledWithCountry: Country?
-    public var methodLastCalledWithTag: Int?
 
-    func onCountrySelected(country: Country, tag: Int) {
+    func onCountrySelected(country: Country) {
         methodCalledTimes += 1
         methodLastCalledWithCountry = country
-        methodLastCalledWithTag = tag
     }
 }
 

--- a/Tests/UI/CountrySelectionViewControllerTests.swift
+++ b/Tests/UI/CountrySelectionViewControllerTests.swift
@@ -3,13 +3,14 @@ import Checkout
 @testable import Frames
 
 class MockDelegate: CountrySelectionViewControllerDelegate {
-
     public var methodCalledTimes = 0
     public var methodLastCalledWithCountry: Country?
+    public var methodLastCalledWithTag: Int?
 
-    func onCountrySelected(country: Country) {
+    func onCountrySelected(country: Country, tag: Int) {
         methodCalledTimes += 1
         methodLastCalledWithCountry = country
+        methodLastCalledWithTag = tag
     }
 }
 

--- a/Tests/UI/New UI/BillingForm/View/BillingFormButtonViewTests.swift
+++ b/Tests/UI/New UI/BillingForm/View/BillingFormButtonViewTests.swift
@@ -29,8 +29,9 @@ class BillingFormButtonViewTests: XCTestCase {
         XCTAssertEqual(view.image?.tintColor, style.button.disabledTintColor)
     }
 
-    func testErrorStyle() {
-        XCTAssertEqual(view.errorView?.isHidden, style.error.isHidden)
+    func testErrorStyle() throws {
+        let isHidden = try XCTUnwrap(view.errorView?.isHidden)
+        XCTAssertTrue(isHidden)
     }
 
 }

--- a/Tests/UI/New UI/BillingForm/View/BillingFormTextFieldViewTests.swift
+++ b/Tests/UI/New UI/BillingForm/View/BillingFormTextFieldViewTests.swift
@@ -10,7 +10,7 @@ class BillingFormTextFieldViewTests: XCTestCase {
         UIFont.loadAllCheckoutFonts
         style = DefaultBillingFormFullNameCellStyle()
         view = TextFieldView()
-        view.update(style: style, type: .fullName(nil))
+        view.update(style: style, type: .fullName(nil), tag: 0)
     }
 
     func testHeaderLabelStyle() {

--- a/Tests/UI/New UI/BillingForm/ViewModel/BillingFormViewModelTests.swift
+++ b/Tests/UI/New UI/BillingForm/ViewModel/BillingFormViewModelTests.swift
@@ -38,12 +38,12 @@ class BillingFormViewModelTests: XCTestCase {
         let viewModel = DefaultBillingFormViewModel(style: DefaultBillingFormStyle(), data: nil)
         let expectedType = BillingFormCell.fullName(nil)
         let text = "fullName"
-        let tag = 2
+        let tag = 0
         let textField = BillingFormTextField(type: expectedType, tag: tag)
         textField.text = text
 
         viewModel.validate(text: textField.text, cellStyle: expectedType, row: tag)
-        XCTAssertEqual( viewModel.errorFlagOfCellType[expectedType.index], false)
+        XCTAssertEqual(viewModel.errorFlagOfCellType[expectedType.index], false)
     }
 
     func testCallDelegateMethodTextFieldIsChanged() {
@@ -74,7 +74,7 @@ class BillingFormViewModelTests: XCTestCase {
         let data = BillingForm(name: name, address: address, phone: phone)
         viewModel.textValueOfCellType = textValueOfCellType
         viewModel.delegate = delegate
-        viewModel.update(country: country)
+        viewModel.update(country: country, tag: 0)
         viewModel.doneButtonIsPressed(sender: UIViewController())
 
         XCTAssertEqual(delegate.onTapDoneButtonCalledTimes, 1)

--- a/Tests/UI/New UI/BillingForm/ViewModel/BillingFormViewModelTests.swift
+++ b/Tests/UI/New UI/BillingForm/ViewModel/BillingFormViewModelTests.swift
@@ -39,7 +39,7 @@ class BillingFormViewModelTests: XCTestCase {
         let expectedType = BillingFormCell.fullName(nil)
         let text = "fullName"
         let tag = 0
-        let textField = BillingFormTextField(type: expectedType, tag: tag)
+        let textField = DefaultBillingFormTextField(type: expectedType, tag: tag)
         textField.text = text
         
         viewModel.validate(text: textField.text, cellStyle: expectedType, row: tag)
@@ -74,7 +74,7 @@ class BillingFormViewModelTests: XCTestCase {
         let data = BillingForm(name: name, address: address, phone: phone)
         viewModel.textValueOfCellType = textValueOfCellType
         viewModel.delegate = delegate
-        viewModel.update(country: country, tag: 0)
+        viewModel.update(country: country)
         viewModel.doneButtonIsPressed(sender: UIViewController())
         
         XCTAssertEqual(delegate.onTapDoneButtonCalledTimes, 1)


### PR DESCRIPTION
[Jira ticket ](https://checkout.atlassian.net/browse/PIMOB-1240)
## Proposed changes

Add country into the correct field when the fields passed in BillingFormCell are changes

Issue: 
When I add a country in, it should always go in the country field even if I change how many fields are passed in BillingFormCell
BillingFormFactory.defaultBillingFormStyle contains 8 BillingFormCell injected, if this is changed to 7 the editing of each text field value is seen to be impacted and interchanged which is not expected. 

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
