### PR TITLE
Feature/PIMOB-1274: Expiry date validation logic

### DIFF
--- a/Source/Resources/en.lproj/Localizable.strings
+++ b/Source/Resources/en.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "AddBillingAddress" = "Add billing address";
 "ExpiryDate" = "ExpiryDate";
 "ExpiryDateFormat" = "Format is MM/YY";
-"ExpiryDatePlaceholder" = "MM/YY";
+"ExpiryDatePlaceholder" = "_ _ /_ _";
 "ExpiryDateErrorMessage" = "Missing Expiry Date";
 "CardNumber" = "Card Number";
 "CardNumberErrorMessage" = "Missing Card Number";

--- a/Source/UI/NewUI/PaymentForm/View/ExpiryDateView.swift
+++ b/Source/UI/NewUI/PaymentForm/View/ExpiryDateView.swift
@@ -73,6 +73,62 @@ public final class ExpiryDateView: UIView {
         updateErrorView(isHidden: false, text: newDate)
     }
   }
+
+  /*
+   Input validation from location 0 to 4 (MM/yy):
+   ===============
+
+   if location 0 (first month digit)
+      if user enters a number between 2-9,
+          then move to the year selector and append a 0 before the digit
+
+   if location 1 (2nd month digit)
+      if user enters a 0,
+          then enter any digit between 1-9
+      if user enters a 1,
+          then enter any digit between 0-2
+
+   if location 3 (backslash '/')
+      then user must enter a number between 2-9 to start with
+
+   if location 4 (first year digit)
+      then user must enter a number between 2-9 to start with
+
+   if location 5 (2nd year digit)
+      then validate full Expiry Date
+   */
+
+  private func validateInput(_ textField: UITextField, currentDigit: Int, location: Int, replacementText: String) -> Bool {
+    switch location {
+
+      case 0 where 2...9 ~= currentDigit:
+        textField.text = "0"
+
+      case 1:
+        guard let originalText = textField.text, let previousDigit = Int(originalText) else { return false }
+
+        switch previousDigit {
+          case  0 where 1...9 ~= currentDigit,
+                1 where 0...2 ~= currentDigit: break
+          default: return false
+        }
+
+      case 2:
+        textField.text?.append("/")
+        guard 2...9 ~= currentDigit else { return false }
+
+      case 3:
+        guard 2...9 ~= currentDigit else { return false }
+
+      case 4:
+        updateExpiryDate(to: (textField.text ?? "") + replacementText)
+        return false
+
+      default: break
+    }
+
+    return true
+  }
 }
 
 extension ExpiryDateView: TextFieldViewDelegate {
@@ -116,58 +172,6 @@ extension ExpiryDateView: TextFieldViewDelegate {
     guard CharacterSet(charactersIn: replacementText).isSubset(of: .decimalDigits) else { return false }
     guard let currentDigit = Int(replacementText) else { return false }
 
-    /*
-     Input validation from location 0 to 4 (MM/yy):
-     ===============
-
-     if location 0 (first month digit)
-        if user enters a number between 2-9,
-            then move to the year selector and append a 0 before the digit
-
-     if location 1 (2nd month digit)
-        if user enters a 0,
-            then enter any digit between 1-9
-        if user enters a 1,
-            then enter any digit between 0-2
-
-     if location 3 (backslash '/')
-        then user must enter a number between 2-9 to start with
-
-     if location 4 (first year digit)
-        then user must enter a number between 2-9 to start with
-
-     if location 5 (2nd year digit)
-        then validate full Expiry Date
-     */
-
-    switch range.location {
-
-      case 0 where 2...9 ~= currentDigit:
-        textField.text = "0"
-
-      case 1:
-        guard let originalText = textField.text, let previousDigit = Int(originalText) else { return false }
-
-        switch previousDigit {
-          case  0 where 1...9 ~= currentDigit,
-                1 where 0...2 ~= currentDigit: break
-          default: return false
-        }
-
-      case 2:
-        textField.text?.append("/")
-        guard 2...9 ~= currentDigit else { return false }
-
-      case 3:
-        guard 2...9 ~= currentDigit else { return false }
-
-      case 4:
-        updateExpiryDate(to: (textField.text ?? "") + replacementText)
-        return false
-
-      default: break
-    }
-
-    return true
+    return validateInput(textField, currentDigit: currentDigit, location: range.location, replacementText: replacementText)
   }
 }

--- a/Source/UI/NewUI/PaymentForm/View/ExpiryDateView.swift
+++ b/Source/UI/NewUI/PaymentForm/View/ExpiryDateView.swift
@@ -110,22 +110,64 @@ extension ExpiryDateView: TextFieldViewDelegate {
     //check for max length including added spacers which all equal to 5
     guard !string.isEmpty else { return false }
     
-    var originalText = textField.text
     let replacementText = string.replacingOccurrences(of: " ", with: "")
     
     //verify entered text is a numeric value
-    if !CharacterSet(charactersIn: replacementText).isSubset(of: .decimalDigits) { return false }
-    
-    //put `/` space after 2 digit
-    if range.location == 2 {
-      originalText?.append("/")
-      textField.text = originalText
+    guard CharacterSet(charactersIn: replacementText).isSubset(of: .decimalDigits) else { return false }
+    guard let currentDigit = Int(replacementText) else { return false }
+
+    /*
+     Input validation from location 0 to 4 (MM/yy):
+     ===============
+
+     if location 0 (first month digit)
+        if user enters a number between 2-9,
+            then move to the year selector and append a 0 before the digit
+
+     if location 1 (2nd month digit)
+        if user enters a 0,
+            then enter any digit between 1-9
+        if user enters a 1,
+            then enter any digit between 0-2
+
+     if location 3 (backslash '/')
+        then user must enter a number between 2-9 to start with
+
+     if location 4 (first year digit)
+        then user must enter a number between 2-9 to start with
+
+     if location 5 (2nd year digit)
+        then validate full Expiry Date
+     */
+
+    switch range.location {
+
+      case 0 where 2...9 ~= currentDigit:
+        textField.text = "0"
+
+      case 1:
+        guard let originalText = textField.text, let previousDigit = Int(originalText) else { return false }
+
+        switch previousDigit {
+          case  0 where 1...9 ~= currentDigit,
+                1 where 0...2 ~= currentDigit: break
+          default: return false
+        }
+
+      case 2:
+        textField.text?.append("/")
+        guard 2...9 ~= currentDigit else { return false }
+
+      case 3:
+        guard 2...9 ~= currentDigit else { return false }
+
+      case 4:
+        updateExpiryDate(to: (textField.text ?? "") + replacementText)
+        return false
+
+      default: break
     }
-    
-    if range.location == dateFormatTextCount - 1 {
-      updateExpiryDate(to: (originalText ?? "") + replacementText)
-      return false
-    }
+
     return true
   }
 }

--- a/Tests/UI/New UI/BillingForm/View/ExpiryDateViewTests.swift
+++ b/Tests/UI/New UI/BillingForm/View/ExpiryDateViewTests.swift
@@ -91,28 +91,23 @@ class ExpiryDateViewTests: XCTestCase {
     }
 
   func testValidFirstDigitInputWith0() {
-    let input = "0"
     let textField = UITextField()
     textField.text = ""
+    let input = "0"
 
     let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 0), replacementString: input)
-    if shouldContinueAdding {
-      textField.text?.append(input)
-    }
-
     XCTAssertTrue(shouldContinueAdding)
+
+    textField.text?.append(input)
     XCTAssertEqual(textField.text, "0")
   }
 
   func testInvalidSecondDigitInputWith0() {
-    let input = "0"
     let textField = UITextField()
     textField.text = "0"
+    let input = "0"
 
     let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 0), replacementString: input)
-    if shouldContinueAdding {
-      textField.text?.append(input)
-    }
 
     XCTAssertFalse(shouldContinueAdding)
     XCTAssertEqual(textField.text, "0")
@@ -124,11 +119,9 @@ class ExpiryDateViewTests: XCTestCase {
     let input = "3"
 
     let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 0), replacementString: input)
-    if shouldContinueAdding {
-      textField.text?.append(input)
-    }
-
     XCTAssertTrue(shouldContinueAdding)
+
+    textField.text?.append(input)
     XCTAssertEqual(textField.text, "03")
   }
 
@@ -138,11 +131,9 @@ class ExpiryDateViewTests: XCTestCase {
     let input = "2"
 
     let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 0), replacementString: input)
-    if shouldContinueAdding {
-      textField.text?.append(input)
-    }
-
     XCTAssertTrue(shouldContinueAdding)
+
+    textField.text?.append(input)
     XCTAssertEqual(textField.text, "12")
   }
 
@@ -152,9 +143,7 @@ class ExpiryDateViewTests: XCTestCase {
     let input = "9"
 
     let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 0), replacementString: input)
-    if shouldContinueAdding {
-      textField.text?.append(input)
-    }
+
     XCTAssertFalse(shouldContinueAdding)
     XCTAssertEqual(textField.text, "1")
   }
@@ -165,9 +154,7 @@ class ExpiryDateViewTests: XCTestCase {
     let input = "0"
 
     let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 0), replacementString: input)
-    if shouldContinueAdding {
-      textField.text?.append(input)
-    }
+
     XCTAssertFalse(shouldContinueAdding)
     XCTAssertEqual(textField.text, "01/")
   }
@@ -178,9 +165,7 @@ class ExpiryDateViewTests: XCTestCase {
     let input = "1"
 
     let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 0), replacementString: input)
-    if shouldContinueAdding {
-      textField.text?.append(input)
-    }
+
     XCTAssertFalse(shouldContinueAdding)
     XCTAssertEqual(textField.text, "02/")
   }
@@ -191,10 +176,9 @@ class ExpiryDateViewTests: XCTestCase {
     let input = "2"
 
     let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 0), replacementString: input)
-    if shouldContinueAdding {
-      textField.text?.append(input)
-    }
     XCTAssertTrue(shouldContinueAdding)
+
+    textField.text?.append(input)
     XCTAssertEqual(textField.text, "02/2")
   }
 
@@ -204,10 +188,9 @@ class ExpiryDateViewTests: XCTestCase {
     let input = "2"
 
     let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 3, length: 0), replacementString: input)
-    if shouldContinueAdding {
-      textField.text?.append(input)
-    }
     XCTAssertTrue(shouldContinueAdding)
+
+    textField.text?.append(input)
     XCTAssertEqual(textField.text, "02/32")
   }
 
@@ -217,9 +200,7 @@ class ExpiryDateViewTests: XCTestCase {
     let input = "0"
 
     let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 3, length: 0), replacementString: input)
-    if shouldContinueAdding {
-      textField.text?.append(input)
-    }
+
     XCTAssertFalse(shouldContinueAdding)
     XCTAssertEqual(textField.text, "02/2")
   }

--- a/Tests/UI/New UI/BillingForm/View/ExpiryDateViewTests.swift
+++ b/Tests/UI/New UI/BillingForm/View/ExpiryDateViewTests.swift
@@ -89,4 +89,139 @@ class ExpiryDateViewTests: XCTestCase {
         view.updateExpiryDate(to: "Test")
         XCTAssertFalse(view.style?.error?.isHidden ?? true)
     }
+
+  func testValidFirstDigitInputWith0() {
+    let input = "0"
+    let textField = UITextField()
+    textField.text = ""
+
+    let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 0), replacementString: input)
+    if shouldContinueAdding {
+      textField.text?.append(input)
+    }
+
+    XCTAssertTrue(shouldContinueAdding)
+    XCTAssertEqual(textField.text, "0")
+  }
+
+  func testInvalidSecondDigitInputWith0() {
+    let input = "0"
+    let textField = UITextField()
+    textField.text = "0"
+
+    let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 0), replacementString: input)
+    if shouldContinueAdding {
+      textField.text?.append(input)
+    }
+
+    XCTAssertFalse(shouldContinueAdding)
+    XCTAssertEqual(textField.text, "0")
+  }
+
+  func testValidSecondDigitInputWith3() {
+    let textField = UITextField()
+    textField.text = ""
+    let input = "3"
+
+    let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 0), replacementString: input)
+    if shouldContinueAdding {
+      textField.text?.append(input)
+    }
+
+    XCTAssertTrue(shouldContinueAdding)
+    XCTAssertEqual(textField.text, "03")
+  }
+
+  func testValidSecondDigitInputWith2() {
+    let textField = UITextField()
+    textField.text = "1"
+    let input = "2"
+
+    let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 0), replacementString: input)
+    if shouldContinueAdding {
+      textField.text?.append(input)
+    }
+
+    XCTAssertTrue(shouldContinueAdding)
+    XCTAssertEqual(textField.text, "12")
+  }
+
+  func testInvalidSecondDigitInputWith9() {
+    let textField = UITextField()
+    textField.text = "1"
+    let input = "9"
+
+    let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 0), replacementString: input)
+    if shouldContinueAdding {
+      textField.text?.append(input)
+    }
+    XCTAssertFalse(shouldContinueAdding)
+    XCTAssertEqual(textField.text, "1")
+  }
+
+  func testInvalidthirdDigitInputWith0() {
+    let textField = UITextField()
+    textField.text = "01"
+    let input = "0"
+
+    let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 0), replacementString: input)
+    if shouldContinueAdding {
+      textField.text?.append(input)
+    }
+    XCTAssertFalse(shouldContinueAdding)
+    XCTAssertEqual(textField.text, "01/")
+  }
+
+  func testInvalidthirdDigitInputWith1() {
+    let textField = UITextField()
+    textField.text = "02"
+    let input = "1"
+
+    let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 0), replacementString: input)
+    if shouldContinueAdding {
+      textField.text?.append(input)
+    }
+    XCTAssertFalse(shouldContinueAdding)
+    XCTAssertEqual(textField.text, "02/")
+  }
+
+  func testValidthirdDigitInputWith2() {
+    let textField = UITextField()
+    textField.text = "02"
+    let input = "2"
+
+    let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 0), replacementString: input)
+    if shouldContinueAdding {
+      textField.text?.append(input)
+    }
+    XCTAssertTrue(shouldContinueAdding)
+    XCTAssertEqual(textField.text, "02/2")
+  }
+
+  func testValidFourthDigitInputWith2() {
+    let textField = UITextField()
+    textField.text = "02/3"
+    let input = "2"
+
+    let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 3, length: 0), replacementString: input)
+    if shouldContinueAdding {
+      textField.text?.append(input)
+    }
+    XCTAssertTrue(shouldContinueAdding)
+    XCTAssertEqual(textField.text, "02/32")
+  }
+
+  func testInvalidFourthDigitInputWith() {
+    let textField = UITextField()
+    textField.text = "02/2"
+    let input = "0"
+
+    let shouldContinueAdding = view.textField(textField, shouldChangeCharactersIn: NSRange(location: 3, length: 0), replacementString: input)
+    if shouldContinueAdding {
+      textField.text?.append(input)
+    }
+    XCTAssertFalse(shouldContinueAdding)
+    XCTAssertEqual(textField.text, "02/2")
+  }
+  
 }


### PR DESCRIPTION
[Jira ticket](https://checkout.atlassian.net/browse/PIMOB-1274?atlOrigin=eyJpIjoiMDM3ODgxNTJlYTU3NDJlNWJlMGViNzlkNTRmYjY3NjMiLCJwIjoiaiJ9)
## Proposed changes

An invalidMonth would be anything not between [01 - 12]
So if a user inputs 21 as the month, that is of course an invalid month. 
We will handle this with smart month logic, whereby 
if user enters a 0, let them enter any digit between 1-9
if user enters a 1, let them enter any digit between 0-2
if user enters a number between 2-9, then move to the year selector and append a 0 before the digit 

Smart year logic:
User must enter a number between 2-9 to start with 
Happens with a negative year or unexpected value. This would never occur with the keypad

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
