### PR TITLE
fix: if the month is 06/22, I cannot add a date of 05/22

### DIFF
--- a/Source/UI/NewUI/PaymentForm/View/ExpiryDateView.swift
+++ b/Source/UI/NewUI/PaymentForm/View/ExpiryDateView.swift
@@ -41,30 +41,33 @@ public final class ExpiryDateView: UIView {
     dateInputView.update(style: self.style)
   }
 
-  func updateExpiryDate(to newDate: String?) {
-    guard newDate?.count == dateFormatTextCount else {
-      updateErrorViewStyle(isHidden: false, textfieldText: newDate, error: .invalidYear)
-      return
+  func updateExpiryDate(to textfieldText: String, replacementText: String) -> Bool {
+    let date = textfieldText + replacementText
+    guard date.count == dateFormatTextCount else {
+      updateErrorViewStyle(isHidden: false, textfieldText: textfieldText, error: .invalidYear)
+      return false
     }
-    let subString = newDate?.split(separator: "/")
-    guard let month = subString?.first,
+    let subString = date.split(separator: "/")
+    guard let month = subString.first,
           month.count == 2,
           let monthDigit = Int(month),
-          let year = subString?.last,
+          let year = subString.last,
           year.count == 2,
           let yearDigit = Int(year) else {
-      updateErrorViewStyle(isHidden: false, textfieldText: newDate, error: .invalidYear)
-      return
+      updateErrorViewStyle(isHidden: false, textfieldText: textfieldText, error: .invalidYear)
+      return false
     }
 
     switch cardValidator.validate(expiryMonth: monthDigit, expiryYear: yearDigit) {
       case .success:
         let expiryDate = ExpiryDate(month: monthDigit, year: yearDigit)
         delegate?.update(expiryDate: expiryDate)
-        updateErrorViewStyle(isHidden: true, textfieldText: newDate)
+        updateErrorViewStyle(isHidden: true, textfieldText: textfieldText)
+        return true
       case .failure(let error):
         print(error)
-        updateErrorViewStyle(isHidden: false, textfieldText: newDate, error: error)
+        updateErrorViewStyle(isHidden: false, textfieldText: textfieldText, error: error)
+        return false
     }
   }
 
@@ -129,10 +132,7 @@ public final class ExpiryDateView: UIView {
         }
 
       case 4:
-        updateExpiryDate(to: (textField.text ?? "") + replacementText)
-        dateInputView.textFieldContainer.layer.borderColor = style?.textfield.focusBorderColor.cgColor
-        return false
-
+        return updateExpiryDate(to: textField.text ?? "", replacementText: replacementText)
       default: break
     }
 

--- a/Source/UI/NewUI/PaymentForm/View/ExpiryDateView.swift
+++ b/Source/UI/NewUI/PaymentForm/View/ExpiryDateView.swift
@@ -41,7 +41,7 @@ public final class ExpiryDateView: UIView {
     dateInputView.update(style: self.style)
   }
 
-  func validateInputChanges(Of textfieldText: String, newInput: String) -> Bool {
+  func validateInputChanges(of textfieldText: String, newInput: String) -> Bool {
     let date = textfieldText + newInput
     guard date.count == dateFormatTextCount else {
       updateErrorViewStyle(isHidden: false, textfieldText: textfieldText, error: .invalidYear)
@@ -131,7 +131,7 @@ public final class ExpiryDateView: UIView {
         }
 
       case 4:
-        return validateInputChanges(Of: textField.text ?? "", newInput: replacementText)
+        return validateInputChanges(of: textField.text ?? "", newInput: replacementText)
       default: break
     }
 

--- a/Source/UI/NewUI/PaymentForm/View/ExpiryDateView.swift
+++ b/Source/UI/NewUI/PaymentForm/View/ExpiryDateView.swift
@@ -41,8 +41,8 @@ public final class ExpiryDateView: UIView {
     dateInputView.update(style: self.style)
   }
 
-  func updateExpiryDate(to textfieldText: String, replacementText: String) -> Bool {
-    let date = textfieldText + replacementText
+  func validateInputChanges(Of textfieldText: String, newInput: String) -> Bool {
+    let date = textfieldText + newInput
     guard date.count == dateFormatTextCount else {
       updateErrorViewStyle(isHidden: false, textfieldText: textfieldText, error: .invalidYear)
       return false
@@ -131,7 +131,7 @@ public final class ExpiryDateView: UIView {
         }
 
       case 4:
-        return updateExpiryDate(to: textField.text ?? "", replacementText: replacementText)
+        return validateInputChanges(Of: textField.text ?? "", newInput: replacementText)
       default: break
     }
 

--- a/Tests/UI/New UI/BillingForm/View/ExpiryDateViewTests.swift
+++ b/Tests/UI/New UI/BillingForm/View/ExpiryDateViewTests.swift
@@ -15,13 +15,13 @@ class ExpiryDateViewTests: XCTestCase {
   }
 
   func testValidExpiryDate(){
-    let isValid = view.validateInputChanges(Of: "01/7", newInput: "0")
+    let isValid = view.validateInputChanges(of: "01/7", newInput: "0")
     XCTAssertTrue(isValid)
     XCTAssertTrue(view.style?.error?.isHidden ?? false)
   }
 
   func testInValidExpiryDate(){
-    let isValid = view.validateInputChanges(Of: "01/1", newInput: "0")
+    let isValid = view.validateInputChanges(of: "01/1", newInput: "0")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.past)
@@ -31,27 +31,27 @@ class ExpiryDateViewTests: XCTestCase {
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "MM/yy"
     let dateText = dateFormatter.string(from: Date())
-    let isValid = view.validateInputChanges(Of: dateText, newInput: "")
+    let isValid = view.validateInputChanges(of: dateText, newInput: "")
     XCTAssertTrue(isValid)
     XCTAssertTrue(view.style?.error?.isHidden ?? false)
   }
 
   func testEmptyExpiryDate(){
-    let isValid = view.validateInputChanges(Of: "", newInput: "")
+    let isValid = view.validateInputChanges(of: "", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithWrongYearFormat(){
-    let isValid = view.validateInputChanges(Of: "01/2035", newInput: "")
+    let isValid = view.validateInputChanges(of: "01/2035", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithWrongMonthFormat(){
-    let isValid = view.validateInputChanges(Of: "Jan/35", newInput: "")
+    let isValid = view.validateInputChanges(of: "Jan/35", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
@@ -59,63 +59,63 @@ class ExpiryDateViewTests: XCTestCase {
 
 
   func testExpiryDateWithWrongFormat(){
-    let isValid = view.validateInputChanges(Of: "01.35", newInput: "")
+    let isValid = view.validateInputChanges(of: "01.35", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithMoreThan5Characters(){
-    let isValid = view.validateInputChanges(Of: "01/01/01/01", newInput: "")
+    let isValid = view.validateInputChanges(of: "01/01/01/01", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithOutBackSlash(){
-    let isValid = view.validateInputChanges(Of: "01350", newInput: "")
+    let isValid = view.validateInputChanges(of: "01350", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithmoreLess5Characters(){
-    let isValid = view.validateInputChanges(Of: "01/0", newInput: "")
+    let isValid = view.validateInputChanges(of: "01/0", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithString(){
-    let isValid = view.validateInputChanges(Of: "Test", newInput: "")
+    let isValid = view.validateInputChanges(of: "Test", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidMaxDate(){
-    let isValid = view.validateInputChanges(Of: "99/99", newInput: "")
+    let isValid = view.validateInputChanges(of: "99/99", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidMinDate(){
-    let isValid = view.validateInputChanges(Of: "00/00", newInput: "")
+    let isValid = view.validateInputChanges(of: "00/00", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidLongNumbers(){
-    let isValid = view.validateInputChanges(Of: "999999999/999999999", newInput: "")
+    let isValid = view.validateInputChanges(of: "999999999/999999999", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidLongSpecialCharacter(){
-    let isValid = view.validateInputChanges(Of: "-*/@@", newInput: "")
+    let isValid = view.validateInputChanges(of: "-*/@@", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)

--- a/Tests/UI/New UI/BillingForm/View/ExpiryDateViewTests.swift
+++ b/Tests/UI/New UI/BillingForm/View/ExpiryDateViewTests.swift
@@ -15,13 +15,13 @@ class ExpiryDateViewTests: XCTestCase {
   }
 
   func testValidExpiryDate(){
-    let isValid = view.updateExpiryDate(to: "01/7", replacementText: "0")
+    let isValid = view.validateInputChanges(Of: "01/7", newInput: "0")
     XCTAssertTrue(isValid)
     XCTAssertTrue(view.style?.error?.isHidden ?? false)
   }
 
   func testInValidExpiryDate(){
-    let isValid = view.updateExpiryDate(to: "01/1", replacementText: "0")
+    let isValid = view.validateInputChanges(Of: "01/1", newInput: "0")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.past)
@@ -30,28 +30,28 @@ class ExpiryDateViewTests: XCTestCase {
   func testValidTodayExpiryDate(){
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "MM/yy"
-    let updateExpiryDate = dateFormatter.string(from: Date())
-    let isValid = view.updateExpiryDate(to: updateExpiryDate, replacementText: "")
+    let dateText = dateFormatter.string(from: Date())
+    let isValid = view.validateInputChanges(Of: dateText, newInput: "")
     XCTAssertTrue(isValid)
     XCTAssertTrue(view.style?.error?.isHidden ?? false)
   }
 
   func testEmptyExpiryDate(){
-    let isValid = view.updateExpiryDate(to: "", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithWrongYearFormat(){
-    let isValid = view.updateExpiryDate(to: "01/2035", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "01/2035", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithWrongMonthFormat(){
-    let isValid = view.updateExpiryDate(to: "Jan/35", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "Jan/35", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
@@ -59,63 +59,63 @@ class ExpiryDateViewTests: XCTestCase {
 
 
   func testExpiryDateWithWrongFormat(){
-    let isValid = view.updateExpiryDate(to: "01.35", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "01.35", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithMoreThan5Characters(){
-    let isValid = view.updateExpiryDate(to: "01/01/01/01", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "01/01/01/01", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithOutBackSlash(){
-    let isValid = view.updateExpiryDate(to: "01350", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "01350", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithmoreLess5Characters(){
-    let isValid = view.updateExpiryDate(to: "01/0", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "01/0", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithString(){
-    let isValid = view.updateExpiryDate(to: "Test", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "Test", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidMaxDate(){
-    let isValid = view.updateExpiryDate(to: "99/99", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "99/99", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidMinDate(){
-    let isValid = view.updateExpiryDate(to: "00/00", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "00/00", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidLongNumbers(){
-    let isValid = view.updateExpiryDate(to: "999999999/999999999", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "999999999/999999999", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidLongSpecialCharacter(){
-    let isValid = view.updateExpiryDate(to: "-*/@@", replacementText: "")
+    let isValid = view.validateInputChanges(Of: "-*/@@", newInput: "")
     XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)

--- a/Tests/UI/New UI/BillingForm/View/ExpiryDateViewTests.swift
+++ b/Tests/UI/New UI/BillingForm/View/ExpiryDateViewTests.swift
@@ -15,28 +15,14 @@ class ExpiryDateViewTests: XCTestCase {
   }
 
   func testValidExpiryDate(){
-    guard let nextMonthDate = Calendar.current.date(byAdding: .month, value: 1, to: Date()) else {
-      XCTFail("Next Month Date is empty")
-      return
-    }
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "MM/yy"
-    let updateExpiryDate = dateFormatter.string(from: nextMonthDate)
-    view.updateExpiryDate(to: updateExpiryDate)
-
+    let isValid = view.updateExpiryDate(to: "01/7", replacementText: "0")
+    XCTAssertTrue(isValid)
     XCTAssertTrue(view.style?.error?.isHidden ?? false)
   }
 
   func testInValidExpiryDate(){
-    guard let previousYearDate = Calendar.current.date(byAdding: .year, value: -1, to: Date()) else {
-      XCTFail("Previous Year Date is empty")
-      return
-    }
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "MM/yy"
-    let updateExpiryDate = dateFormatter.string(from: previousYearDate)
-    view.updateExpiryDate(to: updateExpiryDate)
-
+    let isValid = view.updateExpiryDate(to: "01/1", replacementText: "0")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.past)
   }
@@ -45,80 +31,92 @@ class ExpiryDateViewTests: XCTestCase {
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "MM/yy"
     let updateExpiryDate = dateFormatter.string(from: Date())
-    view.updateExpiryDate(to: updateExpiryDate)
-
+    let isValid = view.updateExpiryDate(to: updateExpiryDate, replacementText: "")
+    XCTAssertTrue(isValid)
     XCTAssertTrue(view.style?.error?.isHidden ?? false)
   }
 
   func testEmptyExpiryDate(){
-    view.updateExpiryDate(to: "")
+    let isValid = view.updateExpiryDate(to: "", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithWrongYearFormat(){
-    view.updateExpiryDate(to: "01/2035")
+    let isValid = view.updateExpiryDate(to: "01/2035", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithWrongMonthFormat(){
-    view.updateExpiryDate(to: "Jan/35")
+    let isValid = view.updateExpiryDate(to: "Jan/35", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
 
   func testExpiryDateWithWrongFormat(){
-    view.updateExpiryDate(to: "01.35")
+    let isValid = view.updateExpiryDate(to: "01.35", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithMoreThan5Characters(){
-    view.updateExpiryDate(to: "01/01/01/01")
+    let isValid = view.updateExpiryDate(to: "01/01/01/01", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithOutBackSlash(){
-    view.updateExpiryDate(to: "01350")
+    let isValid = view.updateExpiryDate(to: "01350", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithmoreLess5Characters(){
-    view.updateExpiryDate(to: "01/0")
+    let isValid = view.updateExpiryDate(to: "01/0", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithString(){
-    view.updateExpiryDate(to: "Test")
+    let isValid = view.updateExpiryDate(to: "Test", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidMaxDate(){
-    view.updateExpiryDate(to: "99/99")
+    let isValid = view.updateExpiryDate(to: "99/99", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidMinDate(){
-    view.updateExpiryDate(to: "00/00")
+    let isValid = view.updateExpiryDate(to: "00/00", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidLongNumbers(){
-    view.updateExpiryDate(to: "999999999/999999999")
+    let isValid = view.updateExpiryDate(to: "999999999/999999999", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }
 
   func testExpiryDateWithInvalidLongSpecialCharacter(){
-    view.updateExpiryDate(to: "-*/@@")
+    let isValid = view.updateExpiryDate(to: "-*/@@", replacementText: "")
+    XCTAssertFalse(isValid)
     XCTAssertFalse(view.style?.error?.isHidden ?? true)
     XCTAssertEqual(view.style?.error?.text, Constants.LocalizationKeys.PaymentForm.ExpiryDate.Error.invalid)
   }


### PR DESCRIPTION
[Jira ticket](https://checkout.atlassian.net/jira/software/c/projects/PIMOB/boards/988?modal=detail&selectedIssue=PIMOB-1191)
## Proposed changes

I am a customer of the Merchant | I use the expiry date component | I’m unable to add an MM/YY in that is before the current MM/YYFor example, if the month is 06/22, I cannot add a date of 05/22 in

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
