### PR TITLE
PIMOB-1304:Fix summary value empty value

### DIFF
--- a/Source/UI/NewUI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/NewUI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -82,6 +82,7 @@ class DefaultPaymentViewModel: PaymentViewModel {
   private func updateSummaryValue(with summaryValues: [String?]) -> String {
     summaryValues
       .compactMap { $0?.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
       .joined(separator: "\n\n")
   }
 }

--- a/Tests/UI/New UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/New UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -91,4 +91,31 @@ class PaymentViewModelTests: XCTestCase {
         let expectedSummaryText = try XCTUnwrap(viewModel.paymentFormStyle?.editBillingSummary?.summary?.text)
         XCTAssertEqual(expectedSummaryText, summaryValue)
     }
+
+  func testSummaryTextWithEmptyValue() throws {
+      let userName = "User"
+
+    let address = Address(addressLine1: "Checkout.com",
+                          addressLine2: "",
+                          city: "London city",
+                          state: "London state",
+                          zip: "N12345",
+                          country: Country(iso3166Alpha2: "GB"))
+
+      let phone = Phone(number: "077 1234 1234",
+                        country: Country(iso3166Alpha2: "GB"))
+      let billingFormData = BillingForm(name: userName,
+                                        address: address,
+                                        phone: phone)
+      viewModel = DefaultPaymentViewModel(cardValidator: CardValidator(environment: .sandbox),
+                                          billingFormData: billingFormData,
+                                          paymentFormStyle: DefaultPaymentFormStyle(),
+                                          billingFormStyle: DefaultBillingFormStyle(),
+                                          supportedSchemes: [.unknown])
+
+      let summaryValue = "User\n\nCheckout.com\n\nLondon city\n\nLondon state\n\nN12345\n\nUnited Kingdom\n\n077 1234 1234"
+      viewModel.updateBillingSummaryView()
+      let expectedSummaryText = try XCTUnwrap(viewModel.paymentFormStyle?.editBillingSummary?.summary?.text)
+      XCTAssertEqual(expectedSummaryText, summaryValue)
+  }
 }


### PR DESCRIPTION
## Proposed changes

Bug: 
- when user leave billing form optional field with empty value, it will add gap in summary view

<img src="https://user-images.githubusercontent.com/102961713/179992840-e1589128-41f2-443d-ae75-cf2846d2e48e.png" width=40%>

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
