### PR TITLE
PIMBO-1337: Update some localisations

### DIFF
--- a/Source/Core/Constants/Constants+LocalizationKeys.swift
+++ b/Source/Core/Constants/Constants+LocalizationKeys.swift
@@ -80,8 +80,8 @@ extension Constants {
             }
 
             struct State {
-                static let text = "state".localized
-                static let error = "missingBillingFormState".localized
+                static let text = "County".localized
+                static let error = "missingBillingFormCounty".localized
             }
 
             struct Header {

--- a/Source/Core/Constants/Constants+LocalizationKeys.swift
+++ b/Source/Core/Constants/Constants+LocalizationKeys.swift
@@ -80,7 +80,7 @@ extension Constants {
             }
 
             struct State {
-                static let text = "County".localized
+                static let text = "county".localized
                 static let error = "missingBillingFormCounty".localized
             }
 

--- a/Source/Core/Constants/Constants+Style.swift
+++ b/Source/Core/Constants/Constants+Style.swift
@@ -14,6 +14,10 @@ extension Constants {
       static let animationLength: TimeInterval = 0.25
 
         enum PaymentForm {
+
+          enum Header: Double {
+            case subtitleFontSize = 13
+          }
             enum InputBillingFormButton: Double {
                 case height = 56
                 case width = 0

--- a/Source/Resources/en.lproj/Localizable.strings
+++ b/Source/Resources/en.lproj/Localizable.strings
@@ -20,7 +20,8 @@
 "SecurityCode" = "Security code";
 "SecurityCodeHint" = "3 - 4 digit code on your card";
 "SecurityCodeErrorMessage" = "Please enter a valid security code";
-
+"PaymentHeaderTitle" = "Payment details";
+"PaymentHeaderSubtitle" = "Visa, Mastercard and American Express accepted.";
 "CardNumber" = "Card number";
 "CardNumberErrorMessage" = "Please enter a valid card number";
 "city" = "City";

--- a/Source/Resources/en.lproj/Localizable.strings
+++ b/Source/Resources/en.lproj/Localizable.strings
@@ -37,7 +37,7 @@
 "countryRegion" = "Country";
 "addressLine1" = "Address line 1";
 "addressLine2" = "Address line 2";
-"County" = "County";
+"county" = "County";
 "postalTown" = "Town";
 "postcode" = "Postcode";
 "phone" = "Phone";

--- a/Source/Resources/en.lproj/Localizable.strings
+++ b/Source/Resources/en.lproj/Localizable.strings
@@ -2,7 +2,7 @@
 "missingBillingFormAddressLine1" = "Missing Address Line 1";
 "missingBillingFormAddressLine2" = "Missing Address Line 2";
 "missingBillingFormCity" = "Missing City";
-"missingBillingFormState" = "Missing State";
+"missingBillingFormCounty" = "Missing County";
 "missingBillingFormPostcode" = "Missing Postcode";
 "missingBillingFormPhoneNumber" = "Missing Phone Number";
 "missingBillingFormCountry" = "Missing Country";
@@ -37,7 +37,7 @@
 "countryRegion" = "Country";
 "addressLine1" = "Address line 1";
 "addressLine2" = "Address line 2";
-"state" = "County";
+"County" = "County";
 "postalTown" = "Town";
 "postcode" = "Postcode";
 "phone" = "Phone";

--- a/Source/UI/NewUI/PaymentForm/Default Implementation/DefaultPaymentHeaderCellStyle.swift
+++ b/Source/UI/NewUI/PaymentForm/Default Implementation/DefaultPaymentHeaderCellStyle.swift
@@ -11,7 +11,9 @@ import UIKit
 public struct DefaultPaymentHeaderCellStyle: PaymentHeaderCellStyle {
   public var backgroundColor: UIColor = .clear
   public var headerLabel: ElementStyle? = DefaultHeaderLabelFormStyle(text: Constants.LocalizationKeys.PaymentForm.Header.title)
-  public var subtitleLabel: ElementStyle? = DefaultTitleLabelStyle(text: Constants.LocalizationKeys.PaymentForm.Header.subtitle)
+  public var subtitleLabel: ElementStyle? = DefaultTitleLabelStyle(
+    text: Constants.LocalizationKeys.PaymentForm.Header.subtitle,
+    font: UIFont(graphikStyle: .regular, size: Constants.Style.PaymentForm.Header.subtitleFontSize.rawValue))
   public var schemeIcons: [UIImage?]? = [
     Constants.Bundle.SchemeIcon(scheme: .visa).image,
     Constants.Bundle.SchemeIcon(scheme: .mastercard).image,

--- a/Tests/UI/New UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/New UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -98,7 +98,7 @@ class PaymentViewModelTests: XCTestCase {
     let address = Address(addressLine1: "Checkout.com",
                           addressLine2: "",
                           city: "London city",
-                          state: "London state",
+                          state: "London County",
                           zip: "N12345",
                           country: Country(iso3166Alpha2: "GB"))
 
@@ -113,7 +113,7 @@ class PaymentViewModelTests: XCTestCase {
                                           billingFormStyle: DefaultBillingFormStyle(),
                                           supportedSchemes: [.unknown])
 
-      let summaryValue = "User\n\nCheckout.com\n\nLondon city\n\nLondon state\n\nN12345\n\nUnited Kingdom\n\n077 1234 1234"
+      let summaryValue = "User\n\nCheckout.com\n\nLondon city\n\nLondon County\n\nN12345\n\nUnited Kingdom\n\n077 1234 1234"
       viewModel.updateBillingSummaryView()
       let expectedSummaryText = try XCTUnwrap(viewModel.paymentFormStyle?.editBillingSummary?.summary?.text)
       XCTAssertEqual(expectedSummaryText, summaryValue)


### PR DESCRIPTION
## Proposed changes

Standard validation error text for County is incorrect
Should be:Missing county

Payment header and subtitle 

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments
Fix:

<img src="https://user-images.githubusercontent.com/102961713/180833364-a7f7862b-1c1b-4dc4-b23e-60695a4bab10.png" width =40%>

