### PR TITLE
Fix: The border colour should turn to the standard black colour if I …

### DIFF
--- a/Source/UI/NewUI/CommonUI/View/Component/InputView.swift
+++ b/Source/UI/NewUI/CommonUI/View/Component/InputView.swift
@@ -204,7 +204,8 @@ extension InputView: TextFieldViewDelegate {
     }
 
     func textFieldShouldEndEditing(textField: UITextField, replacementString: String) -> Bool {
-        delegate?.textFieldShouldEndEditing(textField: textField, replacementString: replacementString) ?? true
+        textFieldContainer.layer.borderColor = style?.textfield.normalBorderColor.cgColor
+        return delegate?.textFieldShouldEndEditing(textField: textField, replacementString: replacementString) ?? true
     }
 
     func textFieldShouldChangeCharactersIn(textField: UITextField, replacementString string: String) {

--- a/Source/UI/NewUI/CommonUI/View/Component/InputView.swift
+++ b/Source/UI/NewUI/CommonUI/View/Component/InputView.swift
@@ -204,8 +204,11 @@ extension InputView: TextFieldViewDelegate {
     }
 
     func textFieldShouldEndEditing(textField: UITextField, replacementString: String) -> Bool {
-        textFieldContainer.layer.borderColor = style?.textfield.normalBorderColor.cgColor
-        return delegate?.textFieldShouldEndEditing(textField: textField, replacementString: replacementString) ?? true
+        let shouldEndEditing = delegate?.textFieldShouldEndEditing(textField: textField, replacementString: replacementString) ?? true
+        if shouldEndEditing {
+            textFieldContainer.layer.borderColor = style?.textfield.normalBorderColor.cgColor
+        }
+        return shouldEndEditing
     }
 
     func textFieldShouldChangeCharactersIn(textField: UITextField, replacementString string: String) {


### PR DESCRIPTION

## Proposed change

When I click off the Card number and Expiry date, the border colour remains blue 
You can see this on the screenshot to the right 
The border colour should turn to the standard black colour if I am not selecting that field
<img src="https://user-images.githubusercontent.com/102961713/181038199-a467faea-c4ae-46db-81f9-7e9f10a245a4.png" width=40%>

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
