### PR TITLE
PIMOB-1279: Trigger analytics event on billing VC willAppear

### DIFF
--- a/Source/UI/NewUI/BillingForm/ViewController/BillingFormViewController.swift
+++ b/Source/UI/NewUI/BillingForm/ViewController/BillingFormViewController.swift
@@ -72,6 +72,7 @@ final class BillingFormViewController: UIViewController {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
         setUpKeyboard()
+        viewModel.viewControllerWillAppear()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Source/UI/NewUI/BillingForm/ViewModel/BillingFormViewModel.swift
+++ b/Source/UI/NewUI/BillingForm/ViewModel/BillingFormViewModel.swift
@@ -2,6 +2,7 @@ import Checkout
 
 protocol BillingFormViewModelDelegate: AnyObject {
     func onTapDoneButton(data: BillingForm)
+    func onBillingScreenShown()
 }
 
 protocol BillingFormViewModelEditingDelegate: AnyObject {
@@ -13,4 +14,5 @@ protocol BillingFormViewModel {
     var data: BillingForm? { get }
     var updatedRow: Int? { get }
     var updateRow: (() -> Void)? { get set }
+    func viewControllerWillAppear()
 }

--- a/Source/UI/NewUI/BillingForm/ViewModel/DefaultBillingFormViewModel.swift
+++ b/Source/UI/NewUI/BillingForm/ViewModel/DefaultBillingFormViewModel.swift
@@ -43,6 +43,10 @@ final class DefaultBillingFormViewModel: BillingFormViewModel {
         updateCellsValues()
     }
 
+    func viewControllerWillAppear() {
+        delegate?.onBillingScreenShown()
+    }
+    
     func getHeaderView(delegate: BillingFormHeaderCellDelegate?) -> UIView {
         let isDoneButtonEnabled = textValueOfCellType.values.count == self.style.cells.count
         style.header.doneButton.isEnabled = isDoneButtonEnabled

--- a/Source/UI/NewUI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/NewUI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -97,6 +97,10 @@ class DefaultPaymentViewModel: PaymentViewModel {
 }
 
 extension DefaultPaymentViewModel: BillingFormViewModelDelegate {
+  func onBillingScreenShown() {
+    logger.log(.billingFormPresented)
+  }
+    
   func onTapDoneButton(data: BillingForm) {
     self.billingFormData = data
   }

--- a/Tests/Mocks/BillingFormViewModelMockDelegate.swift
+++ b/Tests/Mocks/BillingFormViewModelMockDelegate.swift
@@ -8,14 +8,15 @@ class BillingFormViewModelMockDelegate: BillingFormViewModelDelegate {
 
     var updateCountryCodeCalledTimes = 0
     var updateCountryCodeLastCalledWithCode: Int?
+    
+    var onBillingScreenShownCounter = 0
 
     func onTapDoneButton(data: BillingForm) {
         onTapDoneButtonCalledTimes += 1
         onTapDoneButtonLastCalledWithData = data
     }
 
-    func updateCountryCode(code: Int) {
-        updateCountryCodeCalledTimes += 1
-        updateCountryCodeLastCalledWithCode = code
+    func onBillingScreenShown() {
+        onBillingScreenShownCounter += 1
     }
 }

--- a/Tests/UI/New UI/BillingForm/ViewController/BillingFormViewControllerTests.swift
+++ b/Tests/UI/New UI/BillingForm/ViewController/BillingFormViewControllerTests.swift
@@ -83,4 +83,36 @@ class BillingFormViewControllerTests: XCTestCase {
         XCTAssertEqual(delegate.estimatedHeightForRowLastCalledWithIndexPath, indexthPath)
     }
 
+    func testBillingViewControllerNotCallingDelegateOnWrongLifecycleEvent() {
+        let fakeDelegate = BillingFormViewModelMockDelegate()
+        let style = DefaultBillingFormStyle()
+        let viewModel = DefaultBillingFormViewModel(style: style, delegate: fakeDelegate)
+        let testVC = BillingFormViewController(viewModel: viewModel)
+        
+        let expect = expectation(description: "Free up main thread in case UI work influences outcome")
+        testVC.viewDidLoad()
+        testVC.viewDidAppear(false)
+        testVC.viewDidLayoutSubviews()
+        testVC.viewWillDisappear(false)
+        testVC.viewDidDisappear(false)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+        
+        XCTAssertEqual(fakeDelegate.onBillingScreenShownCounter, 0)
+    }
+    
+    func testBillingViewControllerCallingDelegateOnLifecycleEvent() {
+        let fakeDelegate = BillingFormViewModelMockDelegate()
+        let style = DefaultBillingFormStyle()
+        let viewModel = DefaultBillingFormViewModel(style: style, delegate: fakeDelegate)
+        let testVC = BillingFormViewController(viewModel: viewModel)
+        
+        testVC.viewWillAppear(true)
+        
+        XCTAssertEqual(fakeDelegate.onBillingScreenShownCounter, 1)
+    }
 }

--- a/Tests/UI/New UI/BillingForm/ViewModel/BillingFormViewModelTests.swift
+++ b/Tests/UI/New UI/BillingForm/ViewModel/BillingFormViewModelTests.swift
@@ -122,10 +122,19 @@ class BillingFormViewModelTests: XCTestCase {
         viewModel.textValueOfCellType = textValueOfCellType
         viewModel.editDelegate = delegate
         
-        viewModel.textFieldShouldEndEditing(textField: DefaultBillingFormTextField(type: .fullName(nil), tag: 2), replacementString: "text")
+        _ = viewModel.textFieldShouldEndEditing(textField: DefaultBillingFormTextField(type: .fullName(nil), tag: 2), replacementString: "text")
         
         XCTAssertEqual(delegate.didFinishEditingBillingFormCalledTimes, 0)
         XCTAssertNil(delegate.didFinishEditingBillingFormLastCalledWithSuccessfully)
+    }
+    
+    func testCallsDelegateWhenViewControllerIsApearing() {
+        let delegate = BillingFormViewModelMockDelegate()
+        let viewModel = DefaultBillingFormViewModel(style: DefaultBillingFormStyle(), delegate: delegate)
+        
+        XCTAssertEqual(delegate.onBillingScreenShownCounter, 0)
+        viewModel.viewControllerWillAppear()
+        XCTAssertEqual(delegate.onBillingScreenShownCounter, 1)
     }
     
 }

--- a/Tests/UI/New UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/New UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -49,6 +49,25 @@ class PaymentViewModelTests: XCTestCase {
         XCTAssertEqual(testLogger.logCalledWithFramesLogEvents.count, 1)
         XCTAssertEqual(testLogger.logCalledWithFramesLogEvents.first, .paymentFormPresented)
     }
+    
+    func testOnBillingScreenShownSendsEventToLogger() {
+        let testLogger = StubFramesEventLogger()
+        let viewModel = DefaultPaymentViewModel(cardValidator: CardValidator(environment: .sandbox),
+                                                logger: testLogger,
+                                                billingFormData: nil,
+                                                paymentFormStyle: nil,
+                                                billingFormStyle: nil,
+                                                supportedSchemes: [])
+        
+        XCTAssertTrue(testLogger.addCalledWithMetadataPairs.isEmpty)
+        XCTAssertTrue(testLogger.logCalledWithFramesLogEvents.isEmpty)
+        
+        viewModel.onBillingScreenShown()
+        
+        XCTAssertTrue(testLogger.addCalledWithMetadataPairs.isEmpty)
+        XCTAssertEqual(testLogger.logCalledWithFramesLogEvents.count, 1)
+        XCTAssertEqual(testLogger.logCalledWithFramesLogEvents.first, .billingFormPresented)
+    }
 
   func testUpdateExpiryDateView() {
       viewModel = DefaultPaymentViewModel(cardValidator: CardValidator(environment: .sandbox),


### PR DESCRIPTION
## Proposed changes

[Jira task](https://checkout.atlassian.net/browse/PIMOB-1279)

✅ Added event when billing vc is getting shown to the user. As owner of the whole journey and already responder of billing updates, I've user Payment view model to receive callback when billing is shown and then trigger event.

🤔 Would be tempted to create a wrapper around Payment VM to remove the responsibilities not strictly within its purpose, but I'm on the edge currently if that's needed. The new object overhead may not justify the benefit for now. Definitely may be a tech debt task creeping up

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_
* [X] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works
