### PR TITLE
PIMOB-1337: Fix error border line for payment UI components 

### DIFF
--- a/Source/UI/NewUI/CommonUI/View/Component/InputView.swift
+++ b/Source/UI/NewUI/CommonUI/View/Component/InputView.swift
@@ -208,7 +208,7 @@ extension InputView: TextFieldViewDelegate {
     func textFieldShouldEndEditing(textField: UITextField, replacementString: String) -> Bool {
         let shouldEndEditing = delegate?.textFieldShouldEndEditing(textField: textField, replacementString: replacementString) ?? true
         if shouldEndEditing {
-            textFieldContainer.layer.borderColor = style?.textfield.normalBorderColor.cgColor
+            textFieldContainer.layer.borderColor = (style?.error?.isHidden ?? true) ? style?.textfield.normalBorderColor.cgColor : style?.textfield.errorBorderColor.cgColor
         }
         return shouldEndEditing
     }


### PR DESCRIPTION
## Proposed changes



- Component border colour should turn red when there is an error on the payment page 
- When there is an error I should see the border of the component red, as you can see here it stays black This issue does not occur on the billing page 

<img src="https://user-images.githubusercontent.com/102961713/182111081-63a7a2cc-180e-4bff-b99a-73ecc3119b96.png" width=40%>


## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
