### PR TITLE
[BUG] - fix unit tests blocking pipelines

### DIFF
--- a/Checkout/Checkout/Integration/CardValidatorTests.swift
+++ b/Checkout/Checkout/Integration/CardValidatorTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import Checkout
+@testable import Checkout
 
 final class CardValidatorTests: XCTestCase {
   private let subject = CardValidator(environment: .sandbox)
@@ -62,15 +62,16 @@ final class CardValidatorTests: XCTestCase {
   }
 
   func test_expiryDate_previousMonth() {
-    let utc12SecondOffset: Double = 60 * 60 * 12
-    let currentDate = Date(timeInterval: -utc12SecondOffset, since: Date())
-    guard let previousMonth = calendar.date(byAdding: .month, value: calendar.component(.day, from: currentDate) > 15 ? -2 : -1, to: currentDate) else {
-      XCTFail("could not build next month date")
-      return
-    }
+    let formatter = DateFormatter()
+    formatter.timeZone = TimeZone.utcMinus12
+    formatter.dateFormat = "yyyy-MM-dd"
+      
+    let testDateString = formatter.string(from: Date())
+    var testDate = formatter.date(from: testDateString)!
+    testDate = calendar.date(byAdding: .month, value: -1, to: testDate)!
 
-    let month = calendar.component(.month, from: previousMonth)
-    let year = calendar.component(.year, from: previousMonth)
+    let month = calendar.component(.month, from: testDate)
+    let year = calendar.component(.year, from: testDate)
 
     let result = subject.validate(expiryMonth: month, expiryYear: year)
 

--- a/Checkout/Checkout/Integration/CardValidatorTests.swift
+++ b/Checkout/Checkout/Integration/CardValidatorTests.swift
@@ -62,7 +62,8 @@ final class CardValidatorTests: XCTestCase {
   }
 
   func test_expiryDate_previousMonth() {
-    let currentDate = Date()
+    let utc12SecondOffset: Double = 60 * 60 * 12
+    let currentDate = Date(timeInterval: -utc12SecondOffset, since: Date())
     guard let previousMonth = calendar.date(byAdding: .month, value: calendar.component(.day, from: currentDate) > 15 ? -2 : -1, to: currentDate) else {
       XCTFail("could not build next month date")
       return


### PR DESCRIPTION
Enable pipelines to not show false failures when some place on Earth is still one month behind compared to the location running the test