### PR TITLE
PIMOB-1366: Enable maestro to validate without cvv

### DIFF
--- a/Checkout/Checkout/Source/Model/Card+Scheme.swift
+++ b/Checkout/Checkout/Source/Model/Card+Scheme.swift
@@ -120,12 +120,13 @@ extension Card {
       switch self {
       case .unknown:
         return Constants.validCVVLengthsUnknownScheme
+      case .maestro:
+          return [0, 3]
       case .americanExpress:
         return [4]
       case .visa,
         .mada,
         .mastercard,
-        .maestro,
         .discover,
         .dinersClub,
         .jcb:

--- a/Checkout/Checkout/Test/Model/CardSchemeTests.swift
+++ b/Checkout/Checkout/Test/Model/CardSchemeTests.swift
@@ -41,10 +41,11 @@ class CardSchemeTests: XCTestCase {
         XCTAssertEqual(scheme.cvvLengths, [0, 3, 4])
       case .americanExpress:
         XCTAssertEqual(scheme.cvvLengths, [4])
+      case .maestro:
+          XCTAssertEqual(scheme.cvvLengths, [0, 3])
       case .visa,
         .mada,
         .mastercard,
-        .maestro,
         .discover,
         .dinersClub,
         .jcb:

--- a/Checkout/Checkout/Test/Validation/CVVValidatorTests.swift
+++ b/Checkout/Checkout/Test/Validation/CVVValidatorTests.swift
@@ -51,8 +51,9 @@ final class CVVValidatorTests: XCTestCase {
   }
 
   func testValidateCVVIncorrectLengthReturnsCorrectError() {
+    let excludedSchemes = [Card.Scheme.maestro, .unknown]
     Card.Scheme.allCases.forEach { scheme in
-      for length in scheme.cvvLengths where scheme != .unknown {
+      for length in scheme.cvvLengths where !excludedSchemes.contains(scheme) {
         // Check too short
         let shortCVV = String((0..<(length - 1)).map { _ in "0123456789".randomElement()! })
         let tooShortResult = subject.validate(
@@ -95,4 +96,18 @@ final class CVVValidatorTests: XCTestCase {
         XCTAssertEqual(validator.validate(cvv: "1234", cardScheme: scheme), .success)
         XCTAssertEqual(validator.validate(cvv: "12345", cardScheme: scheme), .failure(.invalidLength))
     }
+    
+  func testMaestroSchemeLenghtsAndValidations() {
+      let scheme = Card.Scheme.maestro
+      XCTAssertEqual(scheme.cvvLengths, [0, 3])
+      
+      let validator = CVVValidator()
+      
+      XCTAssertEqual(validator.validate(cvv: "", cardScheme: scheme), .success)
+      XCTAssertEqual(validator.validate(cvv: "1", cardScheme: scheme), .failure(.invalidLength))
+      XCTAssertEqual(validator.validate(cvv: "12", cardScheme: scheme), .failure(.invalidLength))
+      XCTAssertEqual(validator.validate(cvv: "123", cardScheme: scheme), .success)
+      XCTAssertEqual(validator.validate(cvv: "1234", cardScheme: scheme), .failure(.invalidLength))
+      XCTAssertEqual(validator.validate(cvv: "12345", cardScheme: scheme), .failure(.invalidLength))
+  }
 }


### PR DESCRIPTION
## Proposed changes

[Jira task](https://checkout.atlassian.net/browse/PIMOB-1366)

Enable a CVV length of 0 for Maestro cards

## Types of changes

What types of changes does your code introduce to Frames Ios?

* [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

* [X] Lint and unit tests pass locally with my changes
* [X] I have added tests that prove my fix is effective or that my feature works