### PR TITLE
PIMOB-1366: Fix accepting maestro cards

### DIFF
--- a/Source/UI/NewUI/PaymentForm/View/CardNumber/CardNumberViewModel.swift
+++ b/Source/UI/NewUI/PaymentForm/View/CardNumber/CardNumberViewModel.swift
@@ -48,9 +48,19 @@ extension CardNumberViewModel: CardNumberViewModelProtocol {
         //    but the number is not complete.
         // In this case we only update delegate if we have a final result to avoiding
         //    overriding the eager validation with a less informative update
-      case let .success((isComplete, scheme)) where isComplete && supportedSchemes.contains(scheme):
-        delegate?.update(result: .success((cardNumber, scheme)))
-        return Constants.Bundle.SchemeIcon(scheme: scheme)
+      case let .success((isComplete, scheme)) where isComplete:
+        let isSupportedScheme = supportedSchemes.contains(where: {
+            if case .maestro = $0,
+               case .maestro = scheme {
+                return true
+            }
+            return $0 == scheme
+        })
+        if isSupportedScheme {
+            delegate?.update(result: .success((cardNumber, scheme)))
+            return Constants.Bundle.SchemeIcon(scheme: scheme)
+        }
+        fallthrough
       case .success,
            .failure:
         delegate?.update(result: .failure(.isNotComplete))

--- a/Tests/UI/New UI/PaymentForm/CardNumber/CardNumberViewModelTests.swift
+++ b/Tests/UI/New UI/PaymentForm/CardNumber/CardNumberViewModelTests.swift
@@ -163,4 +163,26 @@ class CardNumberViewModelTests: XCTestCase {
     XCTAssertNil(result)
     XCTAssertEqual(mockCardValidator.receivedValidateCompletenessCardNumbers, ["1234"])
   }
+    
+    func testValidateMaestroIgnoresAssociatedValueWhenSupported() {
+        let mockValidator = MockCardValidator()
+        mockValidator.expectedValidateCompletenessResult = .success((isComplete: true, scheme: .maestro(length: 19)))
+        let testCard = "6799990100000000019"
+        let viewModel = CardNumberViewModel(cardValidator: mockValidator, supportedSchemes: [.maestro(length: 5)])
+        
+        let schemeIcon = viewModel.validate(cardNumber: testCard)
+        XCTAssertEqual(schemeIcon, .maestro)
+        XCTAssertEqual(mockValidator.receivedValidateCompletenessCardNumbers, [testCard])
+    }
+    
+    func testValidateMaestroIgnoresAssociatedValueWhenNotSupported() {
+        let mockValidator = MockCardValidator()
+        mockValidator.expectedValidateCompletenessResult = .success((isComplete: true, scheme: .maestro(length: 19)))
+        let testCard = "6799990100000000019"
+        let viewModel = CardNumberViewModel(cardValidator: mockValidator, supportedSchemes: [.mastercard, .visa, .jcb])
+        
+        let schemeIcon = viewModel.validate(cardNumber: testCard)
+        XCTAssertNil(schemeIcon)
+        XCTAssertEqual(mockValidator.receivedValidateCompletenessCardNumbers, [testCard])
+    }
 }


### PR DESCRIPTION
## Proposed changes

[Jira task](https://checkout.atlassian.net/browse/PIMOB-1366)

In [Previous PR](https://github.com/checkout/frames-ios/pull/242) maestro cards were compared using their associated value (the card number length). Given all `supportedSchemes` come from a parsing that assigns a 0 length as supported, any length maestro would get refused as not supported.

Have improved the check whether we support the detected scheme to ignore any associated value and match regardless of that value.