### PR TITLE
PIMOB-XXXX: Fix swift lint for M1

### DIFF
--- a/iOS Example Frame Carthage/iOS Example Frame Carthage.xcodeproj/project.pbxproj
+++ b/iOS Example Frame Carthage/iOS Example Frame Carthage.xcodeproj/project.pbxproj
@@ -747,8 +747,8 @@
 				0BC60B7428AFB32600F30992 /* Theme+Subtitle.swift */,
 			);
 			path = Generic;
-            sourceTree = "<group>";
-        };
+			sourceTree = "<group>";
+		};
 		0BD4BFA028AE6D6B008ED92E /* Cardholder */ = {
 			isa = PBXGroup;
 			children = (
@@ -1774,6 +1774,7 @@
 				4422775926163748009626A0 /* Sources */,
 				4422775A26163748009626A0 /* Frameworks */,
 				4422775B26163748009626A0 /* Resources */,
+				953A893628AFDCBD00C1CDF5 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1831,6 +1832,7 @@
 				E6646F8720CE6C0900D8353A /* Frameworks */,
 				E6646F8820CE6C0900D8353A /* Resources */,
 				4422774B26163716009626A0 /* Embed Frameworks */,
+				953A893528AFDCA300C1CDF5 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1979,6 +1981,41 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "checkoutEventLoggerKitVersion=\"1.1.1\"\nzipDownload=\"CheckoutEventLoggerKit.zip\"\n\ncurl -L \"https://github.com/checkout/checkout-event-logger-ios-framework/archive/refs/tags/$checkoutEventLoggerKitVersion.zip\" > $zipDownload\nunzip $zipDownload\ncp -r \"checkout-event-logger-ios-framework-$checkoutEventLoggerKitVersion/CheckoutEventLoggerKit.xcframework\" .\nrm -r \"checkout-event-logger-ios-framework-$checkoutEventLoggerKitVersion\"\nrm $zipDownload\n";
+		};
+		953A893528AFDCA300C1CDF5 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Adds support for Apple Silicon brew directory export \nPATH=\"$PATH:/opt/homebrew/bin\"  \n\nif which swiftlint > /dev/null; then\n  swiftlint --fix --config ../.swiftlint.yml\nelse\n  echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		953A893628AFDCBD00C1CDF5 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Adds support for Apple Silicon brew directory export \nPATH=\"$PATH:/opt/homebrew/bin\"  \n\nif which swiftlint > /dev/null; then\n  swiftlint --fix --config ../.swiftlint.yml\nelse\n  echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/iOS Example Frame Carthage/iOS Example Frame Carthage.xcodeproj/project.pbxproj
+++ b/iOS Example Frame Carthage/iOS Example Frame Carthage.xcodeproj/project.pbxproj
@@ -1774,7 +1774,6 @@
 				4422775926163748009626A0 /* Sources */,
 				4422775A26163748009626A0 /* Frameworks */,
 				4422775B26163748009626A0 /* Resources */,
-				953A893628AFDCBD00C1CDF5 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1984,24 +1983,6 @@
 		};
 		953A893528AFDCA300C1CDF5 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Adds support for Apple Silicon brew directory export \nPATH=\"$PATH:/opt/homebrew/bin\"  \n\nif which swiftlint > /dev/null; then\n  swiftlint --fix --config ../.swiftlint.yml\nelse\n  echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		953A893628AFDCBD00C1CDF5 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
+++ b/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
@@ -482,7 +482,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint > /dev/null; then\n  swiftlint --fix --config ../.swiftlint.yml\nelse\n  echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "# Adds support for Apple Silicon brew directory export \nPATH=\"$PATH:/opt/homebrew/bin\"  \n\nif which swiftlint > /dev/null; then\n  swiftlint --fix --config ../.swiftlint.yml\nelse\n  echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/iOS Example Frame/iOS Example Frame.xcodeproj/project.pbxproj
+++ b/iOS Example Frame/iOS Example Frame.xcodeproj/project.pbxproj
@@ -382,6 +382,7 @@
 				E6646F8720CE6C0900D8353A /* Frameworks */,
 				E6646F8820CE6C0900D8353A /* Resources */,
 				AB074D63097241ECA1D82051 /* [CP] Embed Pods Frameworks */,
+				953A893728AFDD2900C1CDF5 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -491,6 +492,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		953A893728AFDD2900C1CDF5 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Adds support for Apple Silicon brew directory export \nPATH=\"$PATH:/opt/homebrew/bin\"  \n\nif which swiftlint > /dev/null; then\n  swiftlint --fix --config ../.swiftlint.yml\nelse\n  echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 		9E6D51F317159F7AB31B3872 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
The logic should be something along the lines of:

- If Homebrew is installed as x86 using Rosetta, then we should use the Rosetta path (/usr/bin/env )
- If Homebrew is installed as arm64, then we should use the M1 path (opt/homebrew)

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
