### PR TITLE
PIMOB-1415: Update Discover card scheme regex

### DIFF
--- a/Checkout/Checkout/Source/Model/Card+Scheme.swift
+++ b/Checkout/Checkout/Source/Model/Card+Scheme.swift
@@ -21,7 +21,7 @@ extension Card {
   ///   - Visa
   public enum Scheme: CaseIterable, Equatable, Hashable {
       
-    public static var allCases: [Card.Scheme] = [.unknown, .mada, .visa, .mastercard, .maestro(length: 0), .americanExpress, .discover, .dinersClub, .jcb]
+    public static var allCases: [Card.Scheme] = [.unknown, .mada, .discover, .maestro(length: 0), .americanExpress, .dinersClub, .jcb, .visa, .mastercard]
       
     private enum Constants {
       static let validCVVLengthsUnknownScheme = [0, 3, 4]
@@ -78,7 +78,7 @@ extension Card {
         return NSRegularExpression(staticPattern: "^3[47]\\d{13}$")
       case .discover:
         // swiftlint:disable:next line_length
-        return NSRegularExpression(staticPattern: "^6(011(0[0-9]|[2-4]\\d|74|7[7-9]|8[6-9]|9[0-9])|4[4-9]\\d{3}|5\\d{4})\\d{10}$")
+        return NSRegularExpression(staticPattern: "^65[4-9][0-9]{13}|64[4-9][0-9]{13}|6011[0-9]{12}|(622(?:12[6-9]|1[3-9][0-9]|[2-8][0-9][0-9]|9[01][0-9]|92[0-5])[0-9]{10})$")
       case .dinersClub:
         return NSRegularExpression(staticPattern: "^3(0[0-5]|[68]\\d)\\d{11,16}$")
       case .jcb:
@@ -107,7 +107,7 @@ extension Card {
       case .americanExpress:
         return NSRegularExpression(staticPattern: "^3[47]")
       case .discover:
-        return NSRegularExpression(staticPattern: "^6(011(0[0-9]|[2-4]|74|7[7-9]|8[6-9]|9[0-9])|4[4-9]|5)")
+        return NSRegularExpression(staticPattern: "^65[4-9]|64[4-9]|6011|(622(?:12[6-9]|1[3-9]|[2-8]|9[01]|92[0-5]))")
       case .dinersClub:
         return NSRegularExpression(staticPattern: "^3(0|[68])")
       case .jcb:

--- a/Checkout/Checkout/Source/Model/Card+Scheme.swift
+++ b/Checkout/Checkout/Source/Model/Card+Scheme.swift
@@ -21,7 +21,7 @@ extension Card {
   ///   - Visa
   public enum Scheme: CaseIterable, Equatable, Hashable {
       
-    public static var allCases: [Card.Scheme] = [.unknown,  .discover, .mada, .mastercard, .maestro(length: 0), .americanExpress, .dinersClub, .jcb .visa]
+    public static var allCases: [Card.Scheme] = [.unknown,  .discover, .mada, .mastercard, .maestro(length: 0), .americanExpress, .dinersClub, .jcb, .visa]
 
       
     private enum Constants {

--- a/Checkout/Checkout/Source/Model/Card+Scheme.swift
+++ b/Checkout/Checkout/Source/Model/Card+Scheme.swift
@@ -21,7 +21,7 @@ extension Card {
   ///   - Visa
   public enum Scheme: CaseIterable, Equatable, Hashable {
       
-    public static var allCases: [Card.Scheme] = [.unknown,  .discover, .mada, .mastercard, .maestro(length: 0), .americanExpress, .dinersClub, .jcb, .visa]
+    public static var allCases: [Card.Scheme] = [.unknown, .discover, .mada, .mastercard, .maestro(length: 0), .americanExpress, .dinersClub, .jcb, .visa]
 
       
     private enum Constants {

--- a/Checkout/Checkout/Source/Model/Card+Scheme.swift
+++ b/Checkout/Checkout/Source/Model/Card+Scheme.swift
@@ -79,7 +79,7 @@ extension Card {
         return NSRegularExpression(staticPattern: "^3[47]\\d{13}$")
       case .discover:
         // swiftlint:disable:next line_length
-        return NSRegularExpression(staticPattern: "^65[4-9][0-9]{13}|64[4-9][0-9]{13}|6011[0-9]{12}|(622(?:12[6-9]|1[3-9][0-9]|[2-8][0-9][0-9]|9[01][0-9]|92[0-5])[0-9]{10})$")
+        return NSRegularExpression(staticPattern: "^65[0-9]{14}|64[4-9][0-9]{13}|6011[0-9]{12}|(622(?:12[6-9]|1[3-9][0-9]|[2-8][0-9][0-9]|9[01][0-9]|92[0-5])[0-9]{10})$")
       case .dinersClub:
         return NSRegularExpression(staticPattern: "^3(0[0-5]|[68]\\d)\\d{11,16}$")
       case .jcb:
@@ -108,7 +108,7 @@ extension Card {
       case .americanExpress:
         return NSRegularExpression(staticPattern: "^3[47]")
       case .discover:
-        return NSRegularExpression(staticPattern: "^65[4-9]|64[4-9]|6011|(622(?:12[6-9]|1[3-9]|[2-8]|9[01]|92[0-5]))")
+        return NSRegularExpression(staticPattern: "^65|64[4-9]|6011|(622(?:12[6-9]|1[3-9]|[2-8]|9[01]|92[0-5]))")
       case .dinersClub:
         return NSRegularExpression(staticPattern: "^3(0|[68])")
       case .jcb:

--- a/Checkout/Checkout/Source/Model/Card+Scheme.swift
+++ b/Checkout/Checkout/Source/Model/Card+Scheme.swift
@@ -21,7 +21,8 @@ extension Card {
   ///   - Visa
   public enum Scheme: CaseIterable, Equatable, Hashable {
       
-    public static var allCases: [Card.Scheme] = [.unknown, .mada, .discover, .maestro(length: 0), .americanExpress, .dinersClub, .jcb, .visa, .mastercard]
+    public static var allCases: [Card.Scheme] = [.unknown,  .discover, .mada, .mastercard, .maestro(length: 0), .americanExpress, .dinersClub, .jcb .visa]
+
       
     private enum Constants {
       static let validCVVLengthsUnknownScheme = [0, 3, 4]

--- a/Checkout/Checkout/Test/Validation/CardNumberValidatorTests.swift
+++ b/Checkout/Checkout/Test/Validation/CardNumberValidatorTests.swift
@@ -26,6 +26,7 @@ final class CardNumberValidatorTests: XCTestCase {
       "6011039964691945": .success(.discover),
       "6441111111111117": .success(.discover),
       "6501111111111117": .success(.discover),
+      "6011111111111117": .success(.discover),
       "3530111333300000": .success(.jcb),
       "5297412542005689": .success(.mada),
       "6759649826438453": .success(.maestro(length: 16)),
@@ -79,6 +80,8 @@ final class CardNumberValidatorTests: XCTestCase {
       "529741": .success(.mada),
       "67": .success(.maestro(length: 2)),
       "55": .success(.mastercard),
+      "65": .success(.discover),
+      "6011": .success(.discover),
       "42": .success(.visa)
     ]
 


### PR DESCRIPTION
## Proposed changes

[Jira task](https://checkout.atlassian.net/browse/PIMOB-1415)

## Further comments

Changing Discover regex to better match eagerly and completely the checked card numbers.

[Source of Regex](https://stackoverflow.com/a/23231321) (_SO_)
[BIN numbers documentation](https://www.bincodes.com/bin-list/) (not 100% source of truth but reasonable guidance)
[Regex validator](https://www.regexpal.com) (have also ran locally to confirm the number provided in the task is behaving correctly.

Have also changed the order of identification for regexes, setting VISA regex to check and setting Discover ahead of Maestro. Reason for this is the overlap on BIN ranges (see BIN numbers link, VISA has all the 4... range)