### PR TITLE
PIMOB-1362(2): Create & Use paymentFormSubmitted logging event

### DIFF
--- a/Source/Core/Logging/FramesLogEvent.swift
+++ b/Source/Core/Logging/FramesLogEvent.swift
@@ -37,6 +37,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
 
     case paymentFormInitialised(environment: Environment)
     case paymentFormPresented
+    case paymentFormSubmitted
     case billingFormPresented
     case threeDSWebviewPresented
     case threeDSChallengeLoaded(success: Bool)
@@ -53,6 +54,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
             return "payment_form_initialised"
         case .paymentFormPresented:
             return "payment_form_presented"
+        case .paymentFormSubmitted:
+            return "payment_form_submitted"
         case .billingFormPresented:
             return "billing_form_presented"
         case .threeDSWebviewPresented:
@@ -70,6 +73,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
         switch self {
         case .paymentFormInitialised,
              .paymentFormPresented,
+             .paymentFormSubmitted,
              .billingFormPresented,
              .threeDSWebviewPresented:
             return .info
@@ -83,8 +87,9 @@ enum FramesLogEvent: Equatable, PropertyProviding {
 
     var properties: [Property: AnyCodable] {
         switch self {
-        case .billingFormPresented,
-             .threeDSWebviewPresented:
+        case .paymentFormSubmitted,
+                .billingFormPresented,
+                .threeDSWebviewPresented:
             return [:]
         case .paymentFormPresented:
             return [Property.locale: Locale.current.identifier].mapValues(AnyCodable.init(_:))

--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -154,14 +154,15 @@ extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
     validateMandatoryInputProvided()
   }
 
-  func payButtonIsPressed() {
-    guard let card = cardDetails.getCard() else { return }
-    isLoading = true
-    checkoutAPIService.createToken(.card(card)) { [weak self] result in
-      self?.isLoading = false
-      self?.cardTokenRequested?(result)
+    func payButtonIsPressed() {
+        guard let card = cardDetails.getCard() else { return }
+        logger.log(.paymentFormSubmitted)
+        isLoading = true
+        checkoutAPIService.createToken(.card(card)) { [weak self] result in
+            self?.isLoading = false
+            self?.cardTokenRequested?(result)
+        }
     }
-  }
 
   func addBillingButtonIsPressed(sender: UINavigationController?) {
     onTapAddressView(sender: sender)

--- a/Tests/Core/Logging/FramesLogEventTests.swift
+++ b/Tests/Core/Logging/FramesLogEventTests.swift
@@ -1,6 +1,5 @@
 import CheckoutEventLoggerKit
 import XCTest
-
 @testable import Frames
 
 final class FramesLogEventTests: XCTestCase {
@@ -47,6 +46,14 @@ final class FramesLogEventTests: XCTestCase {
 
         let subject = createExceptionEvent(message: "message")
         XCTAssertEqual([.message: "message"], subject.properties)
+    }
+    
+    func testPaymentFormSubmittedFormat() {
+        let event = FramesLogEvent.paymentFormSubmitted
+        XCTAssertEqual(event.typeIdentifier, "com.checkout.frames-mobile-sdk.payment_form_submitted")
+        XCTAssertEqual(event.properties, [:])
+        XCTAssertEqual(event.monitoringLevel, .info)
+        XCTAssertEqual(event.rawProperties, [:])
     }
 
     // MARK: - Utility

--- a/Tests/Mocks/StubCheckoutAPIService.swift
+++ b/Tests/Mocks/StubCheckoutAPIService.swift
@@ -10,6 +10,7 @@
 
 final class StubCheckoutAPIService: Frames.CheckoutAPIProtocol {
   var cardValidatorToReturn = MockCardValidator()
+    var callCompletionOnCreateToken = true
   var loggerToReturn = StubFramesEventLogger()
   var logger: FramesEventLogging {
     loggerCalled = true
@@ -30,7 +31,9 @@ final class StubCheckoutAPIService: Frames.CheckoutAPIProtocol {
 
   func createToken(_ paymentSource: PaymentSource, completion: @escaping (Result<TokenDetails, TokenisationError.TokenRequest>) -> Void) {
     createTokenCalledWith = (paymentSource, completion)
-    completion(.success(StubCheckoutAPIService.createTokenDetails()))
+      if callCompletionOnCreateToken {
+          completion(.success(StubCheckoutAPIService.createTokenDetails()))
+      }
   }
 
 }

--- a/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Checkout
 @testable import Frames
 
-class PaymentViewModelTests: XCTestCase {
+final class PaymentViewModelTests: XCTestCase {
 
     var viewModel: DefaultPaymentViewModel!
     
@@ -34,11 +34,11 @@ class PaymentViewModelTests: XCTestCase {
         let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
         let viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                                 cardValidator: CardValidator(environment: .sandbox),
-                                                  logger: testLogger,
-                                                  billingFormData: nil,
-                                                  paymentFormStyle: nil,
-                                                  billingFormStyle: nil,
-                                                  supportedSchemes: [])
+                                                logger: testLogger,
+                                                billingFormData: nil,
+                                                paymentFormStyle: nil,
+                                                billingFormStyle: nil,
+                                                supportedSchemes: [])
         
         XCTAssertTrue(testLogger.addCalledWithMetadataPairs.isEmpty)
         XCTAssertTrue(testLogger.logCalledWithFramesLogEvents.isEmpty)
@@ -55,11 +55,11 @@ class PaymentViewModelTests: XCTestCase {
         let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
         let viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                                 cardValidator: CardValidator(environment: .sandbox),
-                                                  logger: testLogger,
-                                                  billingFormData: nil,
-                                                  paymentFormStyle: nil,
-                                                  billingFormStyle: nil,
-                                                  supportedSchemes: [])
+                                                logger: testLogger,
+                                                billingFormData: nil,
+                                                paymentFormStyle: nil,
+                                                billingFormStyle: nil,
+                                                supportedSchemes: [])
         
         XCTAssertTrue(testLogger.addCalledWithMetadataPairs.isEmpty)
         XCTAssertTrue(testLogger.logCalledWithFramesLogEvents.isEmpty)
@@ -71,10 +71,10 @@ class PaymentViewModelTests: XCTestCase {
         XCTAssertEqual(testLogger.logCalledWithFramesLogEvents.first, .billingFormPresented)
     }
 
-  func testUpdateExpiryDateView() {
-      let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
-      viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
-                                          cardValidator: CardValidator(environment: .sandbox),
+    func testUpdateExpiryDateView() {
+        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
+                                            cardValidator: CardValidator(environment: .sandbox),
                                             logger: StubFramesEventLogger(),
                                             billingFormData: nil,
                                             paymentFormStyle: DefaultPaymentFormStyle(),
@@ -95,11 +95,11 @@ class PaymentViewModelTests: XCTestCase {
         let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
         viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                             cardValidator: CardValidator(environment: .sandbox),
-                                              logger: StubFramesEventLogger(),
-                                              billingFormData: nil,
-                                              paymentFormStyle: DefaultPaymentFormStyle(),
-                                              billingFormStyle: DefaultBillingFormStyle(),
-                                              supportedSchemes: [.unknown])
+                                            logger: StubFramesEventLogger(),
+                                            billingFormData: nil,
+                                            paymentFormStyle: DefaultPaymentFormStyle(),
+                                            billingFormStyle: DefaultBillingFormStyle(),
+                                            supportedSchemes: [.unknown])
         
         let testCardholder = "Hà Tracey"
         viewModel.cardholderIsUpdated(value: testCardholder)
@@ -173,47 +173,47 @@ class PaymentViewModelTests: XCTestCase {
         let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
         viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                             cardValidator: CardValidator(environment: .sandbox),
-                                              logger: StubFramesEventLogger(),
-                                              billingFormData: billingFormData,
-                                              paymentFormStyle: DefaultPaymentFormStyle(),
-                                              billingFormStyle: DefaultBillingFormStyle(),
-                                              supportedSchemes: [.unknown])
-
+                                            logger: StubFramesEventLogger(),
+                                            billingFormData: billingFormData,
+                                            paymentFormStyle: DefaultPaymentFormStyle(),
+                                            billingFormStyle: DefaultBillingFormStyle(),
+                                            supportedSchemes: [.unknown])
+        
         let summaryValue = "User Custom 1\n\n77 1234 1234"
         viewModel.updateBillingSummaryView()
         let expectedSummaryText = try XCTUnwrap(viewModel.paymentFormStyle?.editBillingSummary?.summary?.text)
         XCTAssertEqual(expectedSummaryText, summaryValue)
     }
 
-  func testSummaryTextWithEmptyValue() throws {
-      let userName = "User"
-      let country = Country(iso3166Alpha2: "GB")
+    func testSummaryTextWithEmptyValue() throws {
+        let userName = "User"
+        let country = Country(iso3166Alpha2: "GB")
+        
+        let address = Address(addressLine1: "Checkout.com",
+                              addressLine2: "",
+                              city: "London city",
+                              state: "London County",
+                              zip: "N12345",
+                              country: country)
 
-    let address = Address(addressLine1: "Checkout.com",
-                          addressLine2: "",
-                          city: "London city",
-                          state: "London County",
-                          zip: "N12345",
+        let phone = Phone(number: "077 1234 1234",
                           country: country)
-
-      let phone = Phone(number: "077 1234 1234",
-                        country: country)
-      let billingFormData = BillingForm(name: userName,
-                                        address: address,
-                                        phone: phone)
-      let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
-      viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService, cardValidator: CardValidator(environment: .sandbox),
+        let billingFormData = BillingForm(name: userName,
+                                          address: address,
+                                          phone: phone)
+        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService, cardValidator: CardValidator(environment: .sandbox),
                                             logger: StubFramesEventLogger(),
                                             billingFormData: billingFormData,
                                             paymentFormStyle: DefaultPaymentFormStyle(),
                                             billingFormStyle: DefaultBillingFormStyle(),
                                             supportedSchemes: [.unknown])
-      let countryName = try XCTUnwrap(country?.name)
-      let summaryValue = "User\n\nCheckout.com\n\nLondon city\n\nLondon County\n\nN12345\n\n\(countryName)\n\n077 1234 1234"
-      viewModel.updateBillingSummaryView()
-      let expectedSummaryText = try XCTUnwrap(viewModel.paymentFormStyle?.editBillingSummary?.summary?.text)
-      XCTAssertEqual(expectedSummaryText, summaryValue)
-  }
+        let countryName = try XCTUnwrap(country?.name)
+        let summaryValue = "User\n\nCheckout.com\n\nLondon city\n\nLondon County\n\nN12345\n\n\(countryName)\n\n077 1234 1234"
+        viewModel.updateBillingSummaryView()
+        let expectedSummaryText = try XCTUnwrap(viewModel.paymentFormStyle?.editBillingSummary?.summary?.text)
+        XCTAssertEqual(expectedSummaryText, summaryValue)
+    }
     
     func testPreventDuplicateCardholderInput() {
         let paymentFormStyle = DefaultPaymentFormStyle()
@@ -253,7 +253,7 @@ class PaymentViewModelTests: XCTestCase {
     
     // MARK: Mandatory input validation tests
     func testNoSchemePresentFailMandatoryInput() {
-        let testPaymentForm = makeBillingFormStyle()
+        let testPaymentForm = makePaymentFormStyle()
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
 
         let expectation = expectation(description: "Callback is expected")
@@ -269,7 +269,7 @@ class PaymentViewModelTests: XCTestCase {
     }
     
     func testMandatoryCardholderNotPresentFailMandatoryInput() {
-        let testPaymentForm = makeBillingFormStyle(isCardholderMandatory: true)
+        let testPaymentForm = makePaymentFormStyle(isCardholderMandatory: true)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
         
         let expectation = expectation(description: "Callback is expected")
@@ -287,7 +287,7 @@ class PaymentViewModelTests: XCTestCase {
     
     func testOptionalCardholderNotPresentPassesMandatoryInput() {
         var expectedCallbacks = 3
-        let testPaymentForm = makeBillingFormStyle(isCardholderMandatory: false)
+        let testPaymentForm = makePaymentFormStyle(isCardholderMandatory: false)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
         
         let expectation = expectation(description: "Callback is expected")
@@ -312,7 +312,7 @@ class PaymentViewModelTests: XCTestCase {
     
     func testMissingCardholderPassesMandatoryInput() {
         var expectedCallbacks = 3
-        var testPaymentForm = makeBillingFormStyle(isCardholderMandatory: true)
+        var testPaymentForm = makePaymentFormStyle(isCardholderMandatory: true)
         testPaymentForm.cardholderInput = nil
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
         
@@ -337,7 +337,7 @@ class PaymentViewModelTests: XCTestCase {
     }
     
     func testMandatorySecurityCodeNotPresentFailMandatoryInput() {
-        let testPaymentForm = makeBillingFormStyle(isSecurityCodeMandatory: true)
+        let testPaymentForm = makePaymentFormStyle(isSecurityCodeMandatory: true)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
         
         let expectation = expectation(description: "Callback is expected")
@@ -356,7 +356,7 @@ class PaymentViewModelTests: XCTestCase {
     func testOptionalSecurityCodeNotPresentFailsMandatoryInput() {
         // Business requirements specifically asked that Security Code has specific behaviour
         // If shown it is mandatory, making it optional will have no effect in requiring it
-        let testPaymentForm = makeBillingFormStyle(isSecurityCodeMandatory: true)
+        let testPaymentForm = makePaymentFormStyle(isSecurityCodeMandatory: true)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
         
         let expectation = expectation(description: "Callback is expected")
@@ -374,7 +374,7 @@ class PaymentViewModelTests: XCTestCase {
     
     func testMissingSecurityCodePassesMandatoryInput() {
         var expectedCallbacks = 2
-        var testPaymentForm = makeBillingFormStyle(isSecurityCodeMandatory: true)
+        var testPaymentForm = makePaymentFormStyle(isSecurityCodeMandatory: true)
         testPaymentForm.securityCode = nil
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
         
@@ -398,7 +398,7 @@ class PaymentViewModelTests: XCTestCase {
     }
     
     func testMandatoryBillingNotPresentFailMandatoryInput() {
-        let testPaymentForm = makeBillingFormStyle(isBillingMandatory: true)
+        let testPaymentForm = makePaymentFormStyle(isBillingMandatory: true)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
         
         let expectation = expectation(description: "Callback is expected")
@@ -416,7 +416,7 @@ class PaymentViewModelTests: XCTestCase {
     
     func testOptionalBillingNotPresentPassesMandatoryInput() {
         var expectedCallbacks = 3
-        let testPaymentForm = makeBillingFormStyle(isBillingMandatory: false)
+        let testPaymentForm = makePaymentFormStyle(isBillingMandatory: false)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
         
         let expectation = expectation(description: "Callback is expected")
@@ -441,7 +441,7 @@ class PaymentViewModelTests: XCTestCase {
     
     func testMissingBillingPassesMandatoryInput() {
         var expectedCallbacks = 3
-        var testPaymentForm = makeBillingFormStyle(isBillingMandatory: true)
+        var testPaymentForm = makePaymentFormStyle(isBillingMandatory: true)
         testPaymentForm.editBillingSummary = nil
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
         
@@ -466,7 +466,7 @@ class PaymentViewModelTests: XCTestCase {
     }
     
     func testMissingCardNumberFailMandatoryInput() {
-        let testPaymentForm = makeBillingFormStyle(isCardholderMandatory: true,
+        let testPaymentForm = makePaymentFormStyle(isCardholderMandatory: true,
                                                    isSecurityCodeMandatory: true,
                                                    isBillingMandatory: true)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
@@ -487,7 +487,7 @@ class PaymentViewModelTests: XCTestCase {
     }
     
     func testIncompleteCardNumberFailMandatoryInput() {
-        let testPaymentForm = makeBillingFormStyle(isCardholderMandatory: true,
+        let testPaymentForm = makePaymentFormStyle(isCardholderMandatory: true,
                                                    isSecurityCodeMandatory: true,
                                                    isBillingMandatory: true)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
@@ -509,7 +509,7 @@ class PaymentViewModelTests: XCTestCase {
     }
     
     func testMissingExpiryDateFailMandatoryInput() {
-        let testPaymentForm = makeBillingFormStyle(isCardholderMandatory: true,
+        let testPaymentForm = makePaymentFormStyle(isCardholderMandatory: true,
                                                    isSecurityCodeMandatory: true,
                                                    isBillingMandatory: true)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
@@ -530,7 +530,7 @@ class PaymentViewModelTests: XCTestCase {
     }
     
     func testHistoricExpiryDateFailMandatoryInput() {
-        let testPaymentForm = makeBillingFormStyle(isCardholderMandatory: true,
+        let testPaymentForm = makePaymentFormStyle(isCardholderMandatory: true,
                                                    isSecurityCodeMandatory: true,
                                                    isBillingMandatory: true)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
@@ -553,7 +553,7 @@ class PaymentViewModelTests: XCTestCase {
     
     func testCardNumberAndExpiryDateProvidedAllOtherOptionalMissingIsValid() {
         var expectedCallbacks = 2
-        var testPaymentForm = makeBillingFormStyle(isCardholderMandatory: false,
+        var testPaymentForm = makePaymentFormStyle(isCardholderMandatory: false,
                                                    isSecurityCodeMandatory: false,
                                                    isBillingMandatory: false)
         testPaymentForm.securityCode = nil
@@ -579,7 +579,7 @@ class PaymentViewModelTests: XCTestCase {
     
     func testAllFieldsRequiredAndProvided() {
         var expectedCallbacks = 6
-        let testPaymentForm = makeBillingFormStyle(isCardholderMandatory: true,
+        let testPaymentForm = makePaymentFormStyle(isCardholderMandatory: true,
                                                    isSecurityCodeMandatory: true,
                                                    isBillingMandatory: true)
         let model = makeViewModel(paymentFormStyle: testPaymentForm)
@@ -606,6 +606,41 @@ class PaymentViewModelTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
     
+    func testPayButtonPressedWithoutData() {
+        let paymentFormStyle = makePaymentFormStyle()
+        let fakeService = StubCheckoutAPIService()
+        let fakeLogger = StubFramesEventLogger()
+        let model = makeViewModel(apiService: fakeService, logger: fakeLogger)
+        
+        model.payButtonIsPressed()
+        
+        XCTAssertFalse(model.isLoading)
+        XCTAssertNil(fakeService.createTokenCalledWith)
+        XCTAssertFalse(fakeService.loggerCalled)
+        XCTAssertTrue(fakeLogger.logCalledWithFramesLogEvents.isEmpty)
+    }
+    
+    func testPayButtonPressedWithAllDataValid() {
+        let fakeService = StubCheckoutAPIService()
+        fakeService.callCompletionOnCreateToken = false
+        let fakeLogger = StubFramesEventLogger()
+        let model = makeViewModel(apiService: fakeService, logger: fakeLogger)
+        
+        let cardNumber = "4242424242424242"
+        let expiryDate = ExpiryDate(month: 5, year: 2067)
+        model.update(result: .success((cardNumber: cardNumber, scheme: .visa)))
+        model.expiryDateIsUpdated(result: .success(expiryDate))
+        
+        model.payButtonIsPressed()
+        
+        let expectedPaymentCard = Card(number: cardNumber, expiryDate: expiryDate, name: "", cvv: "", billingAddress: nil, phone: nil)
+        XCTAssertTrue(model.isLoading)
+        XCTAssertNotNil(fakeService.createTokenCalledWith)
+        XCTAssertEqual(fakeService.createTokenCalledWith?.paymentSource, .card(expectedPaymentCard))
+        XCTAssertFalse(fakeService.loggerCalled)
+        XCTAssertEqual(fakeLogger.logCalledWithFramesLogEvents, [.paymentFormSubmitted])
+    }
+    
     private func makeViewModel(apiService: Frames.CheckoutAPIProtocol = StubCheckoutAPIService(),
                                cardValidator: CardValidator = CardValidator(environment: .sandbox),
                                logger: FramesEventLogging = StubFramesEventLogger(),
@@ -626,7 +661,7 @@ class PaymentViewModelTests: XCTestCase {
         BillingForm(name: "John", address: Address(addressLine1: "Kong Drive", addressLine2: "Blister", city: "Dreamland", state: nil, zip: "DR38ML", country: Country.allAvailable.first), phone: nil)
     }
     
-    private func makeBillingFormStyle(isCardholderMandatory: Bool = false,
+    private func makePaymentFormStyle(isCardholderMandatory: Bool = false,
                                       isSecurityCodeMandatory: Bool = false,
                                       isBillingMandatory: Bool = false) -> PaymentFormStyle {
         var style = DefaultPaymentFormStyle()

--- a/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -607,7 +607,6 @@ final class PaymentViewModelTests: XCTestCase {
     }
     
     func testPayButtonPressedWithoutData() {
-        let paymentFormStyle = makePaymentFormStyle()
         let fakeService = StubCheckoutAPIService()
         let fakeLogger = StubFramesEventLogger()
         let model = makeViewModel(apiService: fakeService, logger: fakeLogger)


### PR DESCRIPTION
## Proposed changes

Create new logging event and trigger on button press.

Found an inconsistency in some unit test where a helper method was named inaccurately.