### PR TITLE
PIMOB-1362(3): Create & Use paymentFormOutcome logging event 

### DIFF
--- a/Source/Core/Logging/FramesLogEvent.swift
+++ b/Source/Core/Logging/FramesLogEvent.swift
@@ -44,6 +44,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
     case threeDSChallengeLoaded(success: Bool)
     case threeDSChallengeComplete(success: Bool, tokenID: String?)
     case exception(message: String)
+    case warn(message: String)
 
     var typeIdentifier: String {
         return "com.checkout.frames-mobile-sdk.\(typeIdentifierSuffix)"
@@ -67,6 +68,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
             return "3ds_challenge_loaded"
         case .threeDSChallengeComplete:
             return "3ds_challenge_complete"
+        case .warn:
+            return "warn"
         case .exception:
             return "exception"
         }
@@ -81,6 +84,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
              .billingFormPresented,
              .threeDSWebviewPresented:
             return .info
+        case .warn:
+            return .warn
         case .exception:
             return .error
         case .threeDSChallengeLoaded(let success),
@@ -108,7 +113,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
             return [.success: success]
                 .updating(key: .tokenID, value: tokenID)
                 .mapValues(AnyCodable.init(_:))
-        case let .exception(message):
+        case let .warn(message),
+            let .exception(message):
             return [.message: message]
                 .mapValues(AnyCodable.init(_:))
         }

--- a/Source/Core/Logging/FramesLogEvent.swift
+++ b/Source/Core/Logging/FramesLogEvent.swift
@@ -38,7 +38,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
     case paymentFormInitialised(environment: Environment)
     case paymentFormPresented
     case paymentFormSubmitted
-    case paymentFormOutcome(token: String)
+    case paymentFormSubmittedResult(token: String)
     case billingFormPresented
     case threeDSWebviewPresented
     case threeDSChallengeLoaded(success: Bool)
@@ -58,8 +58,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
             return "payment_form_presented"
         case .paymentFormSubmitted:
             return "payment_form_submitted"
-        case .paymentFormOutcome:
-            return "payment_form_outcome"
+        case .paymentFormSubmittedResult:
+            return "payment_form_submitted_result"
         case .billingFormPresented:
             return "billing_form_presented"
         case .threeDSWebviewPresented:
@@ -80,7 +80,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
         case .paymentFormInitialised,
              .paymentFormPresented,
              .paymentFormSubmitted,
-             .paymentFormOutcome,
+             .paymentFormSubmittedResult,
              .billingFormPresented,
              .threeDSWebviewPresented:
             return .info
@@ -105,7 +105,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
         case let .paymentFormInitialised(environment):
             let environmentString = environment.rawValue == "live" ? "production" : environment.rawValue
             return [.environment: environmentString].mapValues(AnyCodable.init(_:))
-        case let .paymentFormOutcome(token):
+        case let .paymentFormSubmittedResult(token):
             return [.tokenID: AnyCodable(token)]
         case let .threeDSChallengeLoaded(success):
             return [.success: success].mapValues(AnyCodable.init(_:))

--- a/Source/Core/Logging/FramesLogEvent.swift
+++ b/Source/Core/Logging/FramesLogEvent.swift
@@ -38,6 +38,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
     case paymentFormInitialised(environment: Environment)
     case paymentFormPresented
     case paymentFormSubmitted
+    case paymentFormOutcome(token: String)
     case billingFormPresented
     case threeDSWebviewPresented
     case threeDSChallengeLoaded(success: Bool)
@@ -56,6 +57,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
             return "payment_form_presented"
         case .paymentFormSubmitted:
             return "payment_form_submitted"
+        case .paymentFormOutcome:
+            return "payment_form_outcome"
         case .billingFormPresented:
             return "billing_form_presented"
         case .threeDSWebviewPresented:
@@ -74,6 +77,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
         case .paymentFormInitialised,
              .paymentFormPresented,
              .paymentFormSubmitted,
+             .paymentFormOutcome,
              .billingFormPresented,
              .threeDSWebviewPresented:
             return .info
@@ -96,6 +100,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
         case let .paymentFormInitialised(environment):
             let environmentString = environment.rawValue == "live" ? "production" : environment.rawValue
             return [.environment: environmentString].mapValues(AnyCodable.init(_:))
+        case let .paymentFormOutcome(token):
+            return [.tokenID: AnyCodable(token)]
         case let .threeDSChallengeLoaded(success):
             return [.success: success].mapValues(AnyCodable.init(_:))
         case let .threeDSChallengeComplete(success, tokenID):

--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -224,7 +224,7 @@ extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
     private func logTokenResult(_ result: Result<TokenDetails, TokenisationError.TokenRequest>) {
         switch result {
         case .success(let tokenDetails):
-            logger.log(.paymentFormOutcome(token: tokenDetails.token))
+            logger.log(.paymentFormSubmittedResult(token: tokenDetails.token))
         case .failure(let requestError):
             logger.log(.warn(message: "\(requestError.code) " + requestError.localizedDescription))
         }

--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -220,7 +220,7 @@ extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
     guard let viewController = FramesFactory.getBillingFormViewController(style: billingFormStyle, data: billingFormData, delegate: self) else { return }
     sender?.present(viewController, animated: true)
   }
-    
+
     private func logOutcome(_ result: Result<TokenDetails, TokenisationError.TokenRequest>) {
         switch result {
         case .success(let tokenDetails):

--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -159,7 +159,7 @@ extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
         logger.log(.paymentFormSubmitted)
         isLoading = true
         checkoutAPIService.createToken(.card(card)) { [weak self] result in
-            self?.logOutcome(result)
+            self?.logTokenResult(result)
             self?.isLoading = false
             self?.cardTokenRequested?(result)
         }
@@ -221,7 +221,7 @@ extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
     sender?.present(viewController, animated: true)
   }
 
-    private func logOutcome(_ result: Result<TokenDetails, TokenisationError.TokenRequest>) {
+    private func logTokenResult(_ result: Result<TokenDetails, TokenisationError.TokenRequest>) {
         switch result {
         case .success(let tokenDetails):
             logger.log(.paymentFormOutcome(token: tokenDetails.token))

--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -159,6 +159,7 @@ extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
         logger.log(.paymentFormSubmitted)
         isLoading = true
         checkoutAPIService.createToken(.card(card)) { [weak self] result in
+            self?.logOutcome(result)
             self?.isLoading = false
             self?.cardTokenRequested?(result)
         }
@@ -219,6 +220,15 @@ extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
     guard let viewController = FramesFactory.getBillingFormViewController(style: billingFormStyle, data: billingFormData, delegate: self) else { return }
     sender?.present(viewController, animated: true)
   }
+    
+    private func logOutcome(_ result: Result<TokenDetails, TokenisationError.TokenRequest>) {
+        switch result {
+        case .success(let tokenDetails):
+            logger.log(.paymentFormOutcome(token: tokenDetails.token))
+        case .failure(let requestError):
+            logger.log(.warn(message: "\(requestError.code) " + requestError.localizedDescription))
+        }
+    }
 }
 
 extension DefaultPaymentViewModel: CardNumberViewModelDelegate {

--- a/Tests/Core/Logging/FramesLogEventTests.swift
+++ b/Tests/Core/Logging/FramesLogEventTests.swift
@@ -56,11 +56,11 @@ final class FramesLogEventTests: XCTestCase {
         XCTAssertEqual(event.rawProperties, [:])
     }
     
-    func testPaymentFormOutcomeFormat() {
+    func testPaymentFormSubmittedResultFormat() {
         let testToken = "ABCIamAtoken123"
-        let event = FramesLogEvent.paymentFormOutcome(token: testToken)
+        let event = FramesLogEvent.paymentFormSubmittedResult(token: testToken)
 
-        XCTAssertEqual(event.typeIdentifier, "com.checkout.frames-mobile-sdk.payment_form_outcome")
+        XCTAssertEqual(event.typeIdentifier, "com.checkout.frames-mobile-sdk.payment_form_submitted_result")
         XCTAssertEqual(event.properties, [FramesLogEvent.Property.tokenID: AnyCodable(testToken)])
         XCTAssertEqual(event.monitoringLevel, .info)
         XCTAssertEqual(event.rawProperties, ["tokenID": AnyCodable(testToken)])

--- a/Tests/Core/Logging/FramesLogEventTests.swift
+++ b/Tests/Core/Logging/FramesLogEventTests.swift
@@ -65,6 +65,16 @@ final class FramesLogEventTests: XCTestCase {
         XCTAssertEqual(event.monitoringLevel, .info)
         XCTAssertEqual(event.rawProperties, ["tokenID": AnyCodable(testToken)])
     }
+    
+    func testWarnFormat() {
+        let testWarnMessage = "Hello world!"
+        let event = FramesLogEvent.warn(message: testWarnMessage)
+        
+        XCTAssertEqual(event.typeIdentifier, "com.checkout.frames-mobile-sdk.warn")
+        XCTAssertEqual(event.properties, [FramesLogEvent.Property.message: AnyCodable(testWarnMessage)])
+        XCTAssertEqual(event.monitoringLevel, .warn)
+        XCTAssertEqual(event.rawProperties, ["message": AnyCodable(testWarnMessage)])
+    }
 
     // MARK: - Utility
 

--- a/Tests/Core/Logging/FramesLogEventTests.swift
+++ b/Tests/Core/Logging/FramesLogEventTests.swift
@@ -55,6 +55,16 @@ final class FramesLogEventTests: XCTestCase {
         XCTAssertEqual(event.monitoringLevel, .info)
         XCTAssertEqual(event.rawProperties, [:])
     }
+    
+    func testPaymentFormOutcomeFormat() {
+        let testToken = "ABCIamAtoken123"
+        let event = FramesLogEvent.paymentFormOutcome(token: testToken)
+
+        XCTAssertEqual(event.typeIdentifier, "com.checkout.frames-mobile-sdk.payment_form_outcome")
+        XCTAssertEqual(event.properties, [FramesLogEvent.Property.tokenID: AnyCodable(testToken)])
+        XCTAssertEqual(event.monitoringLevel, .info)
+        XCTAssertEqual(event.rawProperties, ["tokenID": AnyCodable(testToken)])
+    }
 
     // MARK: - Utility
 

--- a/Tests/Mocks/StubCheckoutAPIService.swift
+++ b/Tests/Mocks/StubCheckoutAPIService.swift
@@ -10,7 +10,7 @@
 
 final class StubCheckoutAPIService: Frames.CheckoutAPIProtocol {
   var cardValidatorToReturn = MockCardValidator()
-    var callCompletionOnCreateToken = true
+  var createTokenCompletionResult: (Result<TokenDetails, TokenisationError.TokenRequest>)?
   var loggerToReturn = StubFramesEventLogger()
   var logger: FramesEventLogging {
     loggerCalled = true
@@ -29,12 +29,12 @@ final class StubCheckoutAPIService: Frames.CheckoutAPIProtocol {
     self.init()
   }
 
-  func createToken(_ paymentSource: PaymentSource, completion: @escaping (Result<TokenDetails, TokenisationError.TokenRequest>) -> Void) {
-    createTokenCalledWith = (paymentSource, completion)
-      if callCompletionOnCreateToken {
-          completion(.success(StubCheckoutAPIService.createTokenDetails()))
-      }
-  }
+    func createToken(_ paymentSource: PaymentSource, completion: @escaping (Result<TokenDetails, TokenisationError.TokenRequest>) -> Void) {
+        createTokenCalledWith = (paymentSource, completion)
+        if let result = createTokenCompletionResult {
+            completion(result)
+        }
+    }
 
 }
 

--- a/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -655,7 +655,7 @@ final class PaymentViewModelTests: XCTestCase {
         
         XCTAssertFalse(model.isLoading)
         XCTAssertNotNil(fakeService.createTokenCalledWith)
-        XCTAssertEqual(fakeLogger.logCalledWithFramesLogEvents, [.paymentFormSubmitted, .paymentFormOutcome(token: testToken)])
+        XCTAssertEqual(fakeLogger.logCalledWithFramesLogEvents, [.paymentFormSubmitted, .paymentFormSubmittedResult(token: testToken)])
     }
     
     func testPayButtonOutcomeFailure() {

--- a/Tests/UI/PaymentForm/PaymentViewControllerTests.swift
+++ b/Tests/UI/PaymentForm/PaymentViewControllerTests.swift
@@ -125,6 +125,7 @@ class PaymentViewControllerTests: XCTestCase {
     let stubCardValidator = MockCardValidator()
     stubCardValidator.validateCardNumberToReturn = .success(.visa)
     stubCheckoutAPIService.cardValidatorToReturn = stubCardValidator
+      stubCheckoutAPIService.createTokenCompletionResult = .success(StubCheckoutAPIService.createTokenDetails())
     viewController.viewDidLoad()
 
     viewModel.update(result: .success(CardInfo("4242 4242 4242 4242", .visa)))


### PR DESCRIPTION
## Proposed changes

Create new logging event and trigger on completion of tokenisation request.

Report failure of request via a new `warn`  event.