### PR TITLE
PIMOB-1362(4): Create & Use paymentFormCanceled logging event

### DIFF
--- a/Source/Core/Logging/FramesLogEvent.swift
+++ b/Source/Core/Logging/FramesLogEvent.swift
@@ -39,6 +39,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
     case paymentFormPresented
     case paymentFormSubmitted
     case paymentFormOutcome(token: String)
+    case paymentFormCanceled
     case billingFormPresented
     case threeDSWebviewPresented
     case threeDSChallengeLoaded(success: Bool)
@@ -60,6 +61,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
             return "payment_form_submitted"
         case .paymentFormOutcome:
             return "payment_form_outcome"
+        case .paymentFormCanceled:
+            return "payment_form_cancelled"
         case .billingFormPresented:
             return "billing_form_presented"
         case .threeDSWebviewPresented:
@@ -81,6 +84,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
              .paymentFormPresented,
              .paymentFormSubmitted,
              .paymentFormOutcome,
+             .paymentFormCanceled,
              .billingFormPresented,
              .threeDSWebviewPresented:
             return .info
@@ -97,6 +101,7 @@ enum FramesLogEvent: Equatable, PropertyProviding {
     var properties: [Property: AnyCodable] {
         switch self {
         case .paymentFormSubmitted,
+                .paymentFormCanceled,
                 .billingFormPresented,
                 .threeDSWebviewPresented:
             return [:]

--- a/Source/UI/PaymentForm/ViewController/PaymentViewController.swift
+++ b/Source/UI/PaymentForm/ViewController/PaymentViewController.swift
@@ -144,6 +144,7 @@ final class PaymentViewController: UIViewController {
   }
 
   @objc private func popViewController() {
+    viewModel.viewControllerCancelled()
     self.navigationController?.popViewController(animated: true)
   }
 

--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -53,6 +53,10 @@ class DefaultPaymentViewModel: PaymentViewModel {
         logger.log(.paymentFormPresented)
     }
 
+    func viewControllerCancelled() {
+        logger.log(.paymentFormCanceled)
+    }
+
     func updateAll() {
         updateHeaderView?()
         updateCardholderView?()

--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -2,158 +2,158 @@ import UIKit
 import Checkout
 
 class DefaultPaymentViewModel: PaymentViewModel {
-  var updateLoading: (() -> Void)?
-  var updateEditBillingSummaryView: (() -> Void)?
-  var updateAddBillingDetailsView: (() -> Void)?
-  var updateExpiryDateView: (() -> Void)?
-  var updateCardholderView: (() -> Void)?
-  var updateCardNumberView: (() -> Void)?
-  var updateSecurityCodeViewStyle: (() -> Void)?
-  var updatePayButtonView: (() -> Void)?
-  var updateHeaderView: (() -> Void)?
-  var updateSecurityCodeViewScheme: ((Card.Scheme) -> Void)?
-  var shouldEnablePayButton: ((Bool) -> Void)?
-  var cardTokenRequested: ((Result<TokenDetails, TokenisationError.TokenRequest>) -> Void)?
-  var supportedSchemes: [Card.Scheme]
-  var cardValidator: CardValidator
-  var logger: FramesEventLogging
-  var checkoutAPIService: CheckoutAPIProtocol
-  var paymentFormStyle: PaymentFormStyle?
-  var billingFormStyle: BillingFormStyle?
-  var currentScheme: Card.Scheme = .unknown
-  var billingFormData: BillingForm?
-  var isLoading = false {
-    didSet {
-      updateLoading?()
+    var updateLoading: (() -> Void)?
+    var updateEditBillingSummaryView: (() -> Void)?
+    var updateAddBillingDetailsView: (() -> Void)?
+    var updateExpiryDateView: (() -> Void)?
+    var updateCardholderView: (() -> Void)?
+    var updateCardNumberView: (() -> Void)?
+    var updateSecurityCodeViewStyle: (() -> Void)?
+    var updatePayButtonView: (() -> Void)?
+    var updateHeaderView: (() -> Void)?
+    var updateSecurityCodeViewScheme: ((Card.Scheme) -> Void)?
+    var shouldEnablePayButton: ((Bool) -> Void)?
+    var cardTokenRequested: ((Result<TokenDetails, TokenisationError.TokenRequest>) -> Void)?
+    var supportedSchemes: [Card.Scheme]
+    var cardValidator: CardValidator
+    var logger: FramesEventLogging
+    var checkoutAPIService: CheckoutAPIProtocol
+    var paymentFormStyle: PaymentFormStyle?
+    var billingFormStyle: BillingFormStyle?
+    var currentScheme: Card.Scheme = .unknown
+    var billingFormData: BillingForm?
+    var isLoading = false {
+        didSet {
+            updateLoading?()
+        }
     }
-  }
-
-  private var cardDetails = CardCreationModel()
-
-  init(checkoutAPIService: CheckoutAPIProtocol,
-       cardValidator: CardValidator,
-       logger: FramesEventLogging,
-       billingFormData: BillingForm?,
-       paymentFormStyle: PaymentFormStyle?,
-       billingFormStyle: BillingFormStyle?,
-       supportedSchemes: [Card.Scheme]) {
-    self.checkoutAPIService = checkoutAPIService
-    self.supportedSchemes = NSOrderedSet(array: supportedSchemes).array as? [Card.Scheme] ?? []
-    self.cardValidator = cardValidator
-    self.paymentFormStyle = paymentFormStyle
-    self.billingFormStyle = billingFormStyle
-    self.logger = logger
-
-    if let billingFormData = billingFormData {
-      updateBillingData(to: billingFormData)
+    
+    private var cardDetails = CardCreationModel()
+    
+    init(checkoutAPIService: CheckoutAPIProtocol,
+         cardValidator: CardValidator,
+         logger: FramesEventLogging,
+         billingFormData: BillingForm?,
+         paymentFormStyle: PaymentFormStyle?,
+         billingFormStyle: BillingFormStyle?,
+         supportedSchemes: [Card.Scheme]) {
+        self.checkoutAPIService = checkoutAPIService
+        self.supportedSchemes = NSOrderedSet(array: supportedSchemes).array as? [Card.Scheme] ?? []
+        self.cardValidator = cardValidator
+        self.paymentFormStyle = paymentFormStyle
+        self.billingFormStyle = billingFormStyle
+        self.logger = logger
+        
+        if let billingFormData = billingFormData {
+            updateBillingData(to: billingFormData)
+        }
     }
-  }
-
-  func viewControllerWillAppear() {
-    logger.log(.paymentFormPresented)
-  }
-
-  func updateAll() {
-    updateHeaderView?()
-    updateCardholderView?()
-    updateCardNumberView?()
-    updateExpiryDateView?()
-    updateSecurityCodeViewStyle?()
-    updatePayButtonView?()
-    if isAddBillingSummaryNotUpdated() {
-      updateBillingSummaryView()
+    
+    func viewControllerWillAppear() {
+        logger.log(.paymentFormPresented)
     }
-  }
-
-  func updateBillingSummaryView() {
-    guard paymentFormStyle?.editBillingSummary != nil else { return }
-    var summaryValue = [String?]()
-
-    billingFormStyle?.cells.forEach {
-      switch $0 {
-        case .fullName: summaryValue.append(billingFormData?.name)
-        case .addressLine1: summaryValue.append(billingFormData?.address?.addressLine1)
-        case .addressLine2: summaryValue.append(billingFormData?.address?.addressLine2)
-        case .state: summaryValue.append(billingFormData?.address?.state)
-        case .country: summaryValue.append(billingFormData?.address?.country?.name)
-        case .city: summaryValue.append(billingFormData?.address?.city)
-        case .postcode: summaryValue.append(billingFormData?.address?.zip)
-        case .phoneNumber: summaryValue.append(billingFormData?.phone?.number)
-      }
+    
+    func updateAll() {
+        updateHeaderView?()
+        updateCardholderView?()
+        updateCardNumberView?()
+        updateExpiryDateView?()
+        updateSecurityCodeViewStyle?()
+        updatePayButtonView?()
+        if isAddBillingSummaryNotUpdated() {
+            updateBillingSummaryView()
+        }
     }
-
-    let summary = updateSummaryValue(with: summaryValue)
-    guard !summary.isEmpty else {
-      let addBillingSummary = paymentFormStyle?.addBillingSummary ?? DefaultAddBillingDetailsViewStyle()
-      paymentFormStyle?.addBillingSummary = addBillingSummary
-      updateAddBillingDetailsView?()
-      return
+    
+    func updateBillingSummaryView() {
+        guard paymentFormStyle?.editBillingSummary != nil else { return }
+        var summaryValue = [String?]()
+        
+        billingFormStyle?.cells.forEach {
+            switch $0 {
+            case .fullName: summaryValue.append(billingFormData?.name)
+            case .addressLine1: summaryValue.append(billingFormData?.address?.addressLine1)
+            case .addressLine2: summaryValue.append(billingFormData?.address?.addressLine2)
+            case .state: summaryValue.append(billingFormData?.address?.state)
+            case .country: summaryValue.append(billingFormData?.address?.country?.name)
+            case .city: summaryValue.append(billingFormData?.address?.city)
+            case .postcode: summaryValue.append(billingFormData?.address?.zip)
+            case .phoneNumber: summaryValue.append(billingFormData?.phone?.number)
+            }
+        }
+        
+        let summary = updateSummaryValue(with: summaryValue)
+        guard !summary.isEmpty else {
+            let addBillingSummary = paymentFormStyle?.addBillingSummary ?? DefaultAddBillingDetailsViewStyle()
+            paymentFormStyle?.addBillingSummary = addBillingSummary
+            updateAddBillingDetailsView?()
+            return
+        }
+        paymentFormStyle?.editBillingSummary?.summary?.text = summary
+        updateEditBillingSummaryView?()
     }
-    paymentFormStyle?.editBillingSummary?.summary?.text = summary
-    updateEditBillingSummaryView?()
-  }
-
-  private func updateBillingData(to billingForm: BillingForm) {
-    self.billingFormData = billingForm
-    cardDetails.phone = billingForm.phone
-    cardDetails.billingAddress = billingForm.address
-    if let billingName = billingForm.name {
-      cardDetails.name = billingName
-      paymentFormStyle?.cardholderInput?.textfield.text = billingName
-      updateCardholderView?()
+    
+    private func updateBillingData(to billingForm: BillingForm) {
+        self.billingFormData = billingForm
+        cardDetails.phone = billingForm.phone
+        cardDetails.billingAddress = billingForm.address
+        if let billingName = billingForm.name {
+            cardDetails.name = billingName
+            paymentFormStyle?.cardholderInput?.textfield.text = billingName
+            updateCardholderView?()
+        }
+        if isAddBillingSummaryNotUpdated() {
+            updateBillingSummaryView()
+        }
+        validateMandatoryInputProvided()
     }
-    if isAddBillingSummaryNotUpdated() {
-      updateBillingSummaryView()
+    
+    private func isAddBillingSummaryNotUpdated() -> Bool {
+        guard billingFormData?.address != nil ||
+                billingFormData?.phone != nil else {
+            let addBillingSummary = paymentFormStyle?.addBillingSummary ?? DefaultAddBillingDetailsViewStyle()
+            paymentFormStyle?.addBillingSummary = addBillingSummary
+            updateAddBillingDetailsView?()
+            return false
+        }
+        return true
     }
-    validateMandatoryInputProvided()
-  }
-
-  private func isAddBillingSummaryNotUpdated() -> Bool {
-    guard billingFormData?.address != nil ||
-            billingFormData?.phone != nil else {
-      let addBillingSummary = paymentFormStyle?.addBillingSummary ?? DefaultAddBillingDetailsViewStyle()
-      paymentFormStyle?.addBillingSummary = addBillingSummary
-      updateAddBillingDetailsView?()
-      return false
+    
+    private func updateSummaryValue(with summaryValues: [String?]) -> String {
+        summaryValues
+            .compactMap { $0?.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
     }
-    return true
-  }
-
-  private func updateSummaryValue(with summaryValues: [String?]) -> String {
-    summaryValues
-      .compactMap { $0?.trimmingCharacters(in: .whitespaces) }
-      .filter { !$0.isEmpty }
-      .joined(separator: "\n\n")
-  }
-
+    
 }
 
 extension DefaultPaymentViewModel: BillingFormViewModelDelegate {
-  func onBillingScreenShown() {
-    logger.log(.billingFormPresented)
-  }
-
-  func onTapDoneButton(data: BillingForm) {
-    updateBillingData(to: data)
-  }
+    func onBillingScreenShown() {
+        logger.log(.billingFormPresented)
+    }
+    
+    func onTapDoneButton(data: BillingForm) {
+        updateBillingData(to: data)
+    }
 }
 
 extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
-  func expiryDateIsUpdated(result: Result<ExpiryDate, ExpiryDateError>) {
-    switch result {
-      case .failure:
-        cardDetails.expiryDate = nil
-      case .success(let expiryDate):
-        cardDetails.expiryDate = expiryDate
+    func expiryDateIsUpdated(result: Result<ExpiryDate, ExpiryDateError>) {
+        switch result {
+        case .failure:
+            cardDetails.expiryDate = nil
+        case .success(let expiryDate):
+            cardDetails.expiryDate = expiryDate
+        }
+        validateMandatoryInputProvided()
     }
-    validateMandatoryInputProvided()
-  }
-
-  func securityCodeIsUpdated(to newCode: String) {
-    cardDetails.cvv = newCode
-    validateMandatoryInputProvided()
-  }
-
+    
+    func securityCodeIsUpdated(to newCode: String) {
+        cardDetails.cvv = newCode
+        validateMandatoryInputProvided()
+    }
+    
     func payButtonIsPressed() {
         guard let card = cardDetails.getCard() else { return }
         logger.log(.paymentFormSubmitted)
@@ -164,63 +164,63 @@ extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
             self?.cardTokenRequested?(result)
         }
     }
-
-  func addBillingButtonIsPressed(sender: UINavigationController?) {
-    onTapAddressView(sender: sender)
-  }
-
-  func editBillingButtonIsPressed(sender: UINavigationController?) {
-    onTapAddressView(sender: sender)
-  }
-
-  func cardholderIsUpdated(value: String) {
-    cardDetails.name = value
-    validateMandatoryInputProvided()
-  }
-
-  private func validateMandatoryInputProvided() {
-    var isMandatoryInputProvided = false
-    defer { shouldEnablePayButton?(isMandatoryInputProvided) }
-
-    // If a scheme is not recorded the number hasn't started being inputted
-    // so we can safely know mandatory fields are not provided
-    guard let cardScheme = cardDetails.scheme else { return }
-
-    // Check if cardholder is required and if so whether it is provided
-    let isCardholderRequired = paymentFormStyle?.cardholderInput?.isMandatory == true
-    if isCardholderRequired && cardDetails.name.isEmpty { return }
-
-    // Check if security code is displayed and if so whether it is valid
-    // This is business logic that wants Security code to be mandatory whenever its shown
-    let isSecurityCodeRequired = paymentFormStyle?.securityCode != nil
-    if isSecurityCodeRequired, !cardValidator.isValid(cvv: cardDetails.cvv, for: cardScheme) { return }
-
-    // Check if Billing is required and if so whether it exists
-    let isAddBillingRequired = paymentFormStyle?.addBillingSummary?.isMandatory == true
-    let isEditBillingRequired = paymentFormStyle?.editBillingSummary?.isMandatory == true
-    let isBillingRequired = isAddBillingRequired && isEditBillingRequired
-    if isBillingRequired && cardDetails.billingAddress == nil { return }
-
-    // Ensure compulsory fields of Card Number and Expiry date have valid values
-    guard case .success(let scheme) = cardValidator.validateCompleteness(cardNumber: cardDetails.number),
-       scheme.isComplete else {
-        // Incomplete card number
-        return
+    
+    func addBillingButtonIsPressed(sender: UINavigationController?) {
+        onTapAddressView(sender: sender)
     }
-
-    guard let expiryDate = cardDetails.expiryDate,
-      case .success = cardValidator.validate(expiryMonth: expiryDate.month, expiryYear: expiryDate.year) else {
-       // Missing / invalid expiry date
-       return
-      }
-    isMandatoryInputProvided = true
-  }
-
-  private func onTapAddressView(sender: UINavigationController?) {
-    guard let viewController = FramesFactory.getBillingFormViewController(style: billingFormStyle, data: billingFormData, delegate: self) else { return }
-    sender?.present(viewController, animated: true)
-  }
-
+    
+    func editBillingButtonIsPressed(sender: UINavigationController?) {
+        onTapAddressView(sender: sender)
+    }
+    
+    func cardholderIsUpdated(value: String) {
+        cardDetails.name = value
+        validateMandatoryInputProvided()
+    }
+    
+    private func validateMandatoryInputProvided() {
+        var isMandatoryInputProvided = false
+        defer { shouldEnablePayButton?(isMandatoryInputProvided) }
+        
+        // If a scheme is not recorded the number hasn't started being inputted
+        // so we can safely know mandatory fields are not provided
+        guard let cardScheme = cardDetails.scheme else { return }
+        
+        // Check if cardholder is required and if so whether it is provided
+        let isCardholderRequired = paymentFormStyle?.cardholderInput?.isMandatory == true
+        if isCardholderRequired && cardDetails.name.isEmpty { return }
+        
+        // Check if security code is displayed and if so whether it is valid
+        // This is business logic that wants Security code to be mandatory whenever its shown
+        let isSecurityCodeRequired = paymentFormStyle?.securityCode != nil
+        if isSecurityCodeRequired, !cardValidator.isValid(cvv: cardDetails.cvv, for: cardScheme) { return }
+        
+        // Check if Billing is required and if so whether it exists
+        let isAddBillingRequired = paymentFormStyle?.addBillingSummary?.isMandatory == true
+        let isEditBillingRequired = paymentFormStyle?.editBillingSummary?.isMandatory == true
+        let isBillingRequired = isAddBillingRequired && isEditBillingRequired
+        if isBillingRequired && cardDetails.billingAddress == nil { return }
+        
+        // Ensure compulsory fields of Card Number and Expiry date have valid values
+        guard case .success(let scheme) = cardValidator.validateCompleteness(cardNumber: cardDetails.number),
+              scheme.isComplete else {
+            // Incomplete card number
+            return
+        }
+        
+        guard let expiryDate = cardDetails.expiryDate,
+              case .success = cardValidator.validate(expiryMonth: expiryDate.month, expiryYear: expiryDate.year) else {
+            // Missing / invalid expiry date
+            return
+        }
+        isMandatoryInputProvided = true
+    }
+    
+    private func onTapAddressView(sender: UINavigationController?) {
+        guard let viewController = FramesFactory.getBillingFormViewController(style: billingFormStyle, data: billingFormData, delegate: self) else { return }
+        sender?.present(viewController, animated: true)
+    }
+    
     private func logOutcome(_ result: Result<TokenDetails, TokenisationError.TokenRequest>) {
         switch result {
         case .success(let tokenDetails):
@@ -232,20 +232,20 @@ extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
 }
 
 extension DefaultPaymentViewModel: CardNumberViewModelDelegate {
-  func update(result: Result<CardInfo, CardNumberError>) {
-    switch result {
-      case .failure:
-        cardDetails.number = ""
-        cardDetails.scheme = nil
-      case .success(let cardInfo):
-        cardDetails.number = cardInfo.cardNumber
-        cardDetails.scheme = cardInfo.scheme
-        updateSecurityCodeViewScheme?(cardInfo.scheme)
+    func update(result: Result<CardInfo, CardNumberError>) {
+        switch result {
+        case .failure:
+            cardDetails.number = ""
+            cardDetails.scheme = nil
+        case .success(let cardInfo):
+            cardDetails.number = cardInfo.cardNumber
+            cardDetails.scheme = cardInfo.scheme
+            updateSecurityCodeViewScheme?(cardInfo.scheme)
+        }
+        validateMandatoryInputProvided()
     }
-    validateMandatoryInputProvided()
-  }
-
-  func schemeUpdatedEagerly(to newScheme: Card.Scheme) {
-    updateSecurityCodeViewScheme?(newScheme)
-  }
+    
+    func schemeUpdatedEagerly(to newScheme: Card.Scheme) {
+        updateSecurityCodeViewScheme?(newScheme)
+    }
 }

--- a/Source/UI/PaymentForm/ViewModel/PaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/PaymentViewModel.swift
@@ -23,6 +23,7 @@ protocol PaymentViewModel {
   var cardTokenRequested: ((Result<TokenDetails, TokenisationError.TokenRequest>) -> Void)? { get set }
   func updateAll()
   func viewControllerWillAppear()
+  func viewControllerCancelled()
   mutating func preventDuplicateCardholderInput()
 }
 

--- a/Tests/Core/Logging/FramesLogEventTests.swift
+++ b/Tests/Core/Logging/FramesLogEventTests.swift
@@ -66,6 +66,15 @@ final class FramesLogEventTests: XCTestCase {
         XCTAssertEqual(event.rawProperties, ["tokenID": AnyCodable(testToken)])
     }
     
+    func testPaymentFormCanceledFormat() {
+        let event = FramesLogEvent.paymentFormCanceled
+        
+        XCTAssertEqual(event.typeIdentifier, "com.checkout.frames-mobile-sdk.payment_form_cancelled")
+        XCTAssertEqual(event.properties, [:])
+        XCTAssertEqual(event.monitoringLevel, .info)
+        XCTAssertEqual(event.rawProperties, [:])
+    }
+    
     func testWarnFormat() {
         let testWarnMessage = "Hello world!"
         let event = FramesLogEvent.warn(message: testWarnMessage)

--- a/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -31,7 +31,7 @@ final class PaymentViewModelTests: XCTestCase {
     
     func testOnAppearSendsEventToLogger() {
         let testLogger = StubFramesEventLogger()
-        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        let checkoutAPIService = StubCheckoutAPIService()
         let viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                                 cardValidator: CardValidator(environment: .sandbox),
                                                 logger: testLogger,
@@ -48,6 +48,27 @@ final class PaymentViewModelTests: XCTestCase {
         XCTAssertTrue(testLogger.addCalledWithMetadataPairs.isEmpty)
         XCTAssertEqual(testLogger.logCalledWithFramesLogEvents.count, 1)
         XCTAssertEqual(testLogger.logCalledWithFramesLogEvents.first, .paymentFormPresented)
+    }
+    
+    func testViewControllerDismissedSendsEventToLogger() {
+        let testLogger = StubFramesEventLogger()
+        let checkoutAPIService = StubCheckoutAPIService()
+        let viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
+                                                cardValidator: CardValidator(environment: .sandbox),
+                                                logger: testLogger,
+                                                billingFormData: nil,
+                                                paymentFormStyle: nil,
+                                                billingFormStyle: nil,
+                                                supportedSchemes: [])
+        
+        XCTAssertTrue(testLogger.addCalledWithMetadataPairs.isEmpty)
+        XCTAssertTrue(testLogger.logCalledWithFramesLogEvents.isEmpty)
+        
+        viewModel.viewControllerCancelled()
+        
+        XCTAssertTrue(testLogger.addCalledWithMetadataPairs.isEmpty)
+        XCTAssertEqual(testLogger.logCalledWithFramesLogEvents.count, 1)
+        XCTAssertEqual(testLogger.logCalledWithFramesLogEvents.first, .paymentFormCanceled)
     }
     
     func testOnBillingScreenShownSendsEventToLogger() {


### PR DESCRIPTION
## Proposed changes

Create new logging event and trigger when the back arrow is pressed to dismiss the payment view controller. This is user initiated and would equate to a cancel action from the user.
