### PR TITLE
PIMOB-1362(5): Create & Use Billing form lifecycle logging events

### DIFF
--- a/Source/Core/Logging/FramesLogEvent.swift
+++ b/Source/Core/Logging/FramesLogEvent.swift
@@ -41,6 +41,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
     case paymentFormOutcome(token: String)
     case paymentFormCanceled
     case billingFormPresented
+    case billingFormCanceled
+    case billingFormSubmit
     case threeDSWebviewPresented
     case threeDSChallengeLoaded(success: Bool)
     case threeDSChallengeComplete(success: Bool, tokenID: String?)
@@ -65,6 +67,10 @@ enum FramesLogEvent: Equatable, PropertyProviding {
             return "payment_form_cancelled"
         case .billingFormPresented:
             return "billing_form_presented"
+        case .billingFormCanceled:
+            return "billing_form_cancelled"
+        case .billingFormSubmit:
+            return "billing_form_submit"
         case .threeDSWebviewPresented:
             return "3ds_webview_presented"
         case .threeDSChallengeLoaded:
@@ -86,6 +92,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
              .paymentFormOutcome,
              .paymentFormCanceled,
              .billingFormPresented,
+             .billingFormCanceled,
+             .billingFormSubmit,
              .threeDSWebviewPresented:
             return .info
         case .warn:
@@ -103,6 +111,8 @@ enum FramesLogEvent: Equatable, PropertyProviding {
         case .paymentFormSubmitted,
                 .paymentFormCanceled,
                 .billingFormPresented,
+                .billingFormCanceled,
+                .billingFormSubmit,
                 .threeDSWebviewPresented:
             return [:]
         case .paymentFormPresented:

--- a/Source/UI/BillingForm/ViewModel/BillingFormViewModel.swift
+++ b/Source/UI/BillingForm/ViewModel/BillingFormViewModel.swift
@@ -2,6 +2,7 @@ import Checkout
 
 protocol BillingFormViewModelDelegate: AnyObject {
     func onTapDoneButton(data: BillingForm)
+    func onTapCancelButton()
     func onBillingScreenShown()
 }
 

--- a/Source/UI/BillingForm/ViewModel/DefaultBillingFormViewModel.swift
+++ b/Source/UI/BillingForm/ViewModel/DefaultBillingFormViewModel.swift
@@ -270,6 +270,7 @@ extension DefaultBillingFormViewModel: BillingFormViewControllerDelegate {
     }
 
     func cancelButtonIsPressed(sender: UIViewController) {
+        delegate?.onTapCancelButton()
         sender.dismiss(animated: true)
     }
 }

--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -138,7 +138,12 @@ extension DefaultPaymentViewModel: BillingFormViewModelDelegate {
     }
 
     func onTapDoneButton(data: BillingForm) {
+        logger.log(.billingFormSubmit)
         updateBillingData(to: data)
+    }
+
+    func onTapCancelButton() {
+        logger.log(.billingFormCanceled)
     }
 }
 

--- a/Tests/Core/Logging/FramesLogEventTests.swift
+++ b/Tests/Core/Logging/FramesLogEventTests.swift
@@ -75,6 +75,33 @@ final class FramesLogEventTests: XCTestCase {
         XCTAssertEqual(event.rawProperties, [:])
     }
     
+    func testBillingFormPresentedFormat() {
+        let event = FramesLogEvent.billingFormPresented
+        
+        XCTAssertEqual(event.typeIdentifier, "com.checkout.frames-mobile-sdk.billing_form_presented")
+        XCTAssertEqual(event.properties, [:])
+        XCTAssertEqual(event.monitoringLevel, .info)
+        XCTAssertEqual(event.rawProperties, [:])
+    }
+    
+    func testBillingFormCanceledFormat() {
+        let event = FramesLogEvent.billingFormCanceled
+        
+        XCTAssertEqual(event.typeIdentifier, "com.checkout.frames-mobile-sdk.billing_form_cancelled")
+        XCTAssertEqual(event.properties, [:])
+        XCTAssertEqual(event.monitoringLevel, .info)
+        XCTAssertEqual(event.rawProperties, [:])
+    }
+    
+    func testBillingFormSubmitFormat() {
+        let event = FramesLogEvent.billingFormSubmit
+        
+        XCTAssertEqual(event.typeIdentifier, "com.checkout.frames-mobile-sdk.billing_form_submit")
+        XCTAssertEqual(event.properties, [:])
+        XCTAssertEqual(event.monitoringLevel, .info)
+        XCTAssertEqual(event.rawProperties, [:])
+    }
+    
     func testWarnFormat() {
         let testWarnMessage = "Hello world!"
         let event = FramesLogEvent.warn(message: testWarnMessage)

--- a/Tests/Mocks/BillingFormViewModelMockDelegate.swift
+++ b/Tests/Mocks/BillingFormViewModelMockDelegate.swift
@@ -5,6 +5,8 @@ import Checkout
 class BillingFormViewModelMockDelegate: BillingFormViewModelDelegate {
     var onTapDoneButtonCalledTimes = 0
     var onTapDoneButtonLastCalledWithData: BillingForm?
+    
+    var onTapCancelButtonCalledTimes = 0
 
     var updateCountryCodeCalledTimes = 0
     var updateCountryCodeLastCalledWithCode: Int?
@@ -14,6 +16,10 @@ class BillingFormViewModelMockDelegate: BillingFormViewModelDelegate {
     func onTapDoneButton(data: BillingForm) {
         onTapDoneButtonCalledTimes += 1
         onTapDoneButtonLastCalledWithData = data
+    }
+    
+    func onTapCancelButton() {
+        onTapCancelButtonCalledTimes += 1
     }
 
     func onBillingScreenShown() {

--- a/Tests/UI/BillingForm/ViewModel/BillingFormViewModelTests.swift
+++ b/Tests/UI/BillingForm/ViewModel/BillingFormViewModelTests.swift
@@ -126,4 +126,12 @@ class BillingFormViewModelTests: XCTestCase {
         XCTAssertEqual(delegate.onBillingScreenShownCounter, 1)
     }
     
+    func testCancelButtonPressCallDelegate() {
+        let delegate = BillingFormViewModelMockDelegate()
+        let viewModel = DefaultBillingFormViewModel(style: DefaultBillingFormStyle(), delegate: delegate)
+        
+        viewModel.cancelButtonIsPressed(sender: UIViewController())
+        XCTAssertEqual(delegate.onTapCancelButtonCalledTimes, 1)
+    }
+    
 }

--- a/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -699,6 +699,25 @@ final class PaymentViewModelTests: XCTestCase {
         XCTAssertEqual(fakeLogger.logCalledWithFramesLogEvents, [.paymentFormSubmitted, .warn(message: expectedWarnMessage)])
     }
     
+    func testBillingTapDoneCallback() {
+        let testLogger = StubFramesEventLogger()
+        let model = makeViewModel(logger: testLogger)
+        XCTAssertNil(model.billingFormData)
+        
+        let testBillingData = makeMockBillingForm()
+        model.onTapDoneButton(data: testBillingData)
+        XCTAssertEqual(model.billingFormData, testBillingData)
+        XCTAssertEqual(testLogger.logCalledWithFramesLogEvents, [.billingFormSubmit])
+    }
+    
+    func testBillingTapCancelCallback() {
+        let testLogger = StubFramesEventLogger()
+        let model = makeViewModel(logger: testLogger)
+        
+        model.onTapCancelButton()
+        XCTAssertEqual(testLogger.logCalledWithFramesLogEvents, [.billingFormCanceled])
+    }
+    
     private func makeViewModel(apiService: Frames.CheckoutAPIProtocol = StubCheckoutAPIService(),
                                cardValidator: CardValidator = CardValidator(environment: .sandbox),
                                logger: FramesEventLogging = StubFramesEventLogger(),


### PR DESCRIPTION
## Proposed changes

Create new logging events:
- `billingFormCanceled` - Triggered when user presses Cancel (will ignore any changes that may have taken place)
- `billingFormSubmit` - Triggered when user presses Done (only enabled once some changes were made on form)