### PR TITLE
PIMOB-1362(6): Create & Use paymentFormSubmitted logging event

### DIFF
--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -164,7 +164,10 @@ extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
     }
 
     func payButtonIsPressed() {
-        guard let card = cardDetails.getCard() else { return }
+        guard let card = cardDetails.getCard() else {
+            logger.log(.warn(message: "Pay button pressed without all required fields input"))
+            return
+        }
         logger.log(.paymentFormSubmitted)
         isLoading = true
         checkoutAPIService.createToken(.card(card)) { [weak self] result in

--- a/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -637,7 +637,7 @@ final class PaymentViewModelTests: XCTestCase {
         XCTAssertFalse(model.isLoading)
         XCTAssertNil(fakeService.createTokenCalledWith)
         XCTAssertFalse(fakeService.loggerCalled)
-        XCTAssertTrue(fakeLogger.logCalledWithFramesLogEvents.isEmpty)
+        XCTAssertEqual(fakeLogger.logCalledWithFramesLogEvents, [.warn(message: "Pay button pressed without all required fields input")])
     }
     
     func testPayButtonPressedWithAllDataValid() {


### PR DESCRIPTION
## Proposed changes

As [raised in previous PR from chain](https://github.com/checkout/frames-ios/pull/315#discussion_r989928317), pressing the Done button if card details cannot be generated (for now this means missing any number input or expiry date) would result in a silent fail.

Changes proposed log this failure as its something we should not expect to happen, as the pay button getting enabled has more stringent conditions than the card object creation. If it does occur it would be of interest to fix & review processes into how it appeared.