### PR TITLE
PIMOB-XXXX: Include all supported schemes in Default UI sample app

### DIFF
--- a/iOS Example Frame/iOS Example Frame/Factory/Factory.swift
+++ b/iOS Example Frame/iOS Example Frame/Factory/Factory.swift
@@ -42,7 +42,7 @@ enum Factory {
 
     let paymentFormStyle = FramesFactory.defaultPaymentFormStyle
 
-    let supportedSchemes: [CardScheme] = [.visa, .mastercard, .maestro]
+    let supportedSchemes: [CardScheme] = [.mada, .visa, .mastercard, .maestro, .americanExpress, .discover, .dinersClub, .jcb]
 
     let configuration = PaymentFormConfiguration(apiKey: apiKey,
                                                  environment: environment,


### PR DESCRIPTION
As described. @patrick-hoban-cko asked if we can include all supported card schemes on our DefaultUI within sample app.

![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-10-12 at 17 08 25](https://user-images.githubusercontent.com/102028170/195394151-814f18a2-11b7-4d1d-9f43-61426aa08bad.png)
