### PR TITLE
PIMOB-XXXX: Fix SPM formatting for external consumption

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,10 +24,6 @@ let package = Package(
             name: "CheckoutEventLoggerKit",
             url: "https://github.com/checkout/checkout-event-logger-ios-framework.git",
             from: "1.2.0"
-        ),
-        .package(
-            name: "Checkout",
-            path: "./Checkout"
         )
     ],
     targets: [
@@ -43,6 +39,13 @@ let package = Package(
             resources: [
                 .process("Resources")
             ]
+        ),
+        .target(
+            name: "Checkout",
+            dependencies: [
+                "CheckoutEventLoggerKit",
+            ],
+            path: "Checkout"
         ),
         .testTarget(
             name: "FramesTests",


### PR DESCRIPTION
Publicly distributed Packages don't like having a dependency to a local package. More documentation on [Swift forum post](https://forums.swift.org/t/unable-to-integrate-a-remote-package-that-has-local-packages/53146/12):
> The local package must be declared in the root package or in other local dependencies. This means, it is not possible to depend on a regular versioned dependency that declares a local package dependency.

Simple solution is to not have a local package to depend on and escalate that structure to be an internal library of the frames package distribution.