### PR TITLE
PIMOB-XXXX: Improve automatic scroll on keyboard appearance

### DIFF
--- a/Source/UI/PaymentForm/ViewController/PaymentViewController.swift
+++ b/Source/UI/PaymentForm/ViewController/PaymentViewController.swift
@@ -143,7 +143,7 @@ final class PaymentViewController: UIViewController {
 
   @objc private func keyboardWillShow(notification: Notification) {
     guard let userInfo = notification.userInfo,
-      let keyboardFrameValue = userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue else { return }
+    let keyboardFrameValue = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
     var keyboardFrame = keyboardFrameValue.cgRectValue
     keyboardFrame = view.convert(keyboardFrame, from: nil)
     var contentInset: UIEdgeInsets = scrollView.contentInset


### PR DESCRIPTION
## Proposed changes

Replace usage of [keyboardFrameBeginUserInfoKey](https://developer.apple.com/documentation/uikit/uiresponder/1621616-keyboardframebeginuserinfokey) for the estimate of keyboard height with [keyboardFrameEndUserInfoKey](https://developer.apple.com/documentation/uikit/uiresponder/1621578-keyboardframeenduserinfokey).

This is an intended correction, as per their own documentations:
- `keyboardFrameEndUserInfoKey`: A user info key to retrieve the keyboard’s frame **at the end of its animation**
- `keyboardFrameBeginUserInfoKey`: A user info key to retrieve the keyboard’s frame **at the beginning of its animation**

As we need the size to calculate offset needed, the final size would be the most accurate value to use.