### PR TITLE
PIMOB-XXXX: Correct ReadMe Carthage dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you haven't already, [install Carthage](https://github.com/Carthage/Carthage#
 To integrate Frames into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```
-github "checkout/frames-ios" ~> 4
+github "checkout/frames-ios" ~> 4.0.0
 ```
 
 Run `carthage update --use-xcframeworks` to build the framework and drag the built `Frames` into your Xcode project.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you haven't already, [install Carthage](https://github.com/Carthage/Carthage#
 To integrate Frames into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```
-github "checkout/frames-ios" ~> 4.0.0
+github "checkout/frames-ios" ~> 4.0
 ```
 
 Run `carthage update --use-xcframeworks` to build the framework and drag the built `Frames` into your Xcode project.


### PR DESCRIPTION
Carthage wants a minor version number and is not happy simply with a major
```
github "checkout/frames-ios" ~> 4
```

Someone integrating via Carthage will end up with an error and follow up by adding a `.0` after the version, to:
```
github "checkout/frames-ios" ~> 4.0
```

PR will offer correct syntax in ReadMe to prevent issue and time spent understanding it.