### PR TITLE
PostRelease: Fix podspec 

### DIFF
--- a/Checkout.podspec
+++ b/Checkout.podspec
@@ -19,15 +19,4 @@ TODO: Add long description of the pod here.
 
   s.dependency 'CheckoutEventLoggerKit', '1.2.0'
 
-  s.test_spec 'Tests' do |t|
-    t.source_files = 'Checkout/Checkout/Test/**/*'
-    t.requires_app_host = true
-    t.scheme = { :launch_arguments => ['COCOAPODS'] }
-  end
-
-  s.test_spec 'Integration-Tests' do |t|
-    t.source_files = 'Checkout/Checkout/Integration/**/*'
-    t.requires_app_host = true
-    t.scheme = { :launch_arguments => ['COCOAPODS'] }
-  end
 end

--- a/Frames.podspec
+++ b/Frames.podspec
@@ -23,10 +23,4 @@ Pod::Spec.new do |s|
   s.dependency 'CheckoutEventLoggerKit', '1.2.0'
   s.dependency 'Checkout', "#{s.version}"
 
-  s.test_spec do |t|
-    t.source_files = 'Tests/**/*.swift'
-    t.resources = 'Tests/Fixtures/*'
-    t.requires_app_host = true
-    t.scheme = { :environment_variables => { 'COCOAPODS' => true }}
-  end
 end

--- a/iOS Example Frame/Podfile
+++ b/iOS Example Frame/Podfile
@@ -6,7 +6,7 @@ target 'iOS Example Frame' do
   use_frameworks!
 
   # Pods for iOS Example Custom
-  pod 'Frames', :path => '../', :testspecs => ['Tests']
+  pod 'Frames', :path => '../'
   pod 'Checkout', :path => '../'
 
 end

--- a/iOS Example Frame/Podfile.lock
+++ b/iOS Example Frame/Podfile.lock
@@ -1,13 +1,9 @@
 PODS:
-  - Checkout (3.5.3):
+  - Checkout (4.0.0):
     - CheckoutEventLoggerKit (= 1.2.0)
   - CheckoutEventLoggerKit (1.2.0)
-  - Frames (3.5.3):
-    - Checkout (= 3.5.3)
-    - CheckoutEventLoggerKit (= 1.2.0)
-    - PhoneNumberKit (= 3.3.3)
-  - Frames/Tests (3.5.3):
-    - Checkout (= 3.5.3)
+  - Frames (4.0.0):
+    - Checkout (= 4.0.0)
     - CheckoutEventLoggerKit (= 1.2.0)
     - PhoneNumberKit (= 3.3.3)
   - PhoneNumberKit (3.3.3):
@@ -20,7 +16,6 @@ PODS:
 DEPENDENCIES:
   - Checkout (from `../`)
   - Frames (from `../`)
-  - Frames/Tests (from `../`)
 
 SPEC REPOS:
   trunk:
@@ -34,11 +29,11 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Checkout: ab80edf6f4bede430527c23ce36fbdc4c93be314
+  Checkout: 06eeafa41ae7253016ab32f6a7731378a783499e
   CheckoutEventLoggerKit: 03d0076e2aa412df966517a36a3e4e3805b56ecb
-  Frames: 131b3bfe0d02f74838363a06d6f9293e1a4ad183
+  Frames: 939b5d3c5e503dbdac6bcadb3b460dd2e43948f7
   PhoneNumberKit: 4ce83273551c4d2ae10b7361162f4283dd02835f
 
-PODFILE CHECKSUM: 1b60c8f1fe6593ecf6277ac2f00d449dba1b0647
+PODFILE CHECKSUM: 07f3a5ae404c1b006fae27bc610ef74f34a1bfe5
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
## Proposed changes

The pod specs were not linting correctly for releases. This is due to structure changes and mostly misplaced unit tests.

As we are using SPM for our core development & pipeline tests, the tests are already being ran and validated so it doesn't make sense to worry about distributing the pods with unit tests?

I took the easy way and removed them from the podspec.