### PR TITLE
PIMOB-XXXX: Remove overhead from ThreeDSWebViewController initialiser

### DIFF
--- a/Source/UI/3DS/ThreedsWebViewController.swift
+++ b/Source/UI/3DS/ThreedsWebViewController.swift
@@ -29,24 +29,11 @@ public class ThreedsWebViewController: UIViewController {
     // MARK: - Initialization
 
     /// Initializes a web view controller adapted to handle 3dsecure.
-    public convenience init(checkoutAPIService: CheckoutAPIService, successUrl: URL, failUrl: URL) {
-        self.init(
-            checkoutAPIProtocol: checkoutAPIService,
-            successUrl: successUrl,
-            failUrl: failUrl,
-            threeDSWKNavigationHelperFactory: ThreeDSWKNavigationHelperFactory()
-        )
-    }
+    public convenience init(environment: Environment, successUrl: URL, failUrl: URL) {
+        let logger = FramesEventLogger(environment: environment, correlationID: UUID().uuidString)
+        let threeDSWKNavigationHelper = ThreeDSWKNavigationHelperFactory().build(successURL: successUrl, failureURL: failUrl)
 
-    /// Initializes a web view controller adapted to handle 3dsecure.
-    convenience init(
-        checkoutAPIProtocol checkoutAPIService: CheckoutAPIProtocol,
-        successUrl: URL,
-        failUrl: URL,
-        threeDSWKNavigationHelperFactory: ThreeDSWKNavigationHelperFactoryProtocol
-    ) {
-        let threeDSWKNavigationHelper = threeDSWKNavigationHelperFactory.build(successURL: successUrl, failureURL: failUrl)
-        self.init(threeDSWKNavigationHelper: threeDSWKNavigationHelper, logger: checkoutAPIService.logger)
+        self.init(threeDSWKNavigationHelper: threeDSWKNavigationHelper, logger: logger)
     }
 
     init(threeDSWKNavigationHelper: ThreeDSWKNavigationHelping, logger: FramesEventLogging) {

--- a/Tests/UI/3DS/ThreedsWebViewControllerTests.swift
+++ b/Tests/UI/3DS/ThreedsWebViewControllerTests.swift
@@ -115,7 +115,7 @@ class ThreedsWebViewControllerTests: XCTestCase {
     func testInitializationWithUrls() {
         let successUrl =  URL(string: "https://www.successurl.com/")!
         let failUrl =  URL(string: "https://www.failurl.com/")!
-        _ = ThreedsWebViewController(checkoutAPIProtocol: checkoutAPIService, successUrl: successUrl, failUrl: failUrl, threeDSWKNavigationHelperFactory: mockThreeDSWKNavigationHelperFactory)
+        _ = ThreedsWebViewController(environment: .sandbox, successUrl: successUrl, failUrl: failUrl)
     }
 
     func testInitializationNibBundle() {

--- a/iOS Example Frame/iOS Example Frame/ViewController/HomeViewController.swift
+++ b/iOS Example Frame/iOS Example Frame/ViewController/HomeViewController.swift
@@ -101,7 +101,7 @@ class HomeViewController: UIViewController {
         return
     }
 
-    let webViewController = ThreedsWebViewController(checkoutAPIService: checkoutAPIService,
+    let webViewController = ThreedsWebViewController(environment: .sandbox,
                                                      successUrl: Factory.successURL,
                                                      failUrl: Factory.failureURL)
     webViewController.delegate = self


### PR DESCRIPTION
The VC was requesting a network client as part of the initialisation, but only consuming the logging part of the network client, discarding the rest.

Changed initialiser to only request an environment, and use that to create logger directly, reducing complexity and unnecessary overhead.

## Notice
This will require update of ReadMe & Public Docs, but that may be done as part of the next release, not this PR (since latest release is in sync with the current docs & change would not be available via the actual release)