### PR TITLE
PIMOB-1474: Fix navigation bar background color on scrolling

### DIFF
--- a/Source/Extensions/UINavigationControllerExtensions.swift
+++ b/Source/Extensions/UINavigationControllerExtensions.swift
@@ -7,6 +7,8 @@ extension UINavigationController {
 
         if #available(iOS 13.0, *) {
             navigationBar.standardAppearance = originalNavController.navigationBar.standardAppearance
+            navigationBar.compactAppearance = originalNavController.navigationBar.compactAppearance
+            navigationBar.scrollEdgeAppearance = originalNavController.navigationBar.scrollEdgeAppearance
         } else {
             let backgroundColor = originalNavController.navigationBar.backgroundColor
             navigationBar.backgroundColor = backgroundColor
@@ -15,5 +17,6 @@ extension UINavigationController {
             navigationBar.titleTextAttributes = [ .foregroundColor: originalNavController.navigationBar.tintColor ?? .black]
             navigationBar.isTranslucent = true
         }
+        navigationController?.setNeedsStatusBarAppearanceUpdate()
     }
 }

--- a/Tests/Core/Extensions/UINavigationControllerTests.swift
+++ b/Tests/Core/Extensions/UINavigationControllerTests.swift
@@ -25,6 +25,8 @@ final class UINavigationControllerTests: XCTestCase {
 
         if #available(iOS 13.0, *) {
             XCTAssertEqual(currentNavigationController.navigationBar.standardAppearance, mainNavigationController.navigationBar.standardAppearance)
+            XCTAssertEqual(currentNavigationController.navigationBar.compactAppearance, mainNavigationController.navigationBar.compactAppearance)
+            XCTAssertEqual(currentNavigationController.navigationBar.scrollEdgeAppearance, mainNavigationController.navigationBar.scrollEdgeAppearance)
         } else {
             XCTAssertEqual(currentNavigationController.navigationBar.backgroundColor, mainNavigationController.navigationBar.backgroundColor)
             XCTAssertEqual(currentNavigationController.navigationBar.barTintColor, mainNavigationController.navigationBar.barTintColor)

--- a/iOS Example Frame/iOS Example Frame/Extension/UIViewControllerExtension.swift
+++ b/iOS Example Frame/iOS Example Frame/Extension/UIViewControllerExtension.swift
@@ -10,19 +10,23 @@ import UIKit
 
 extension UIViewController {
   func customizeNavigationBarAppearance(backgroundColor: UIColor, foregroundColor: UIColor) {
+    navigationController?.navigationBar.tintColor = foregroundColor
     if #available(iOS 13.0, *) {
-
       let appearance = UINavigationBarAppearance()
-      appearance.configureWithDefaultBackground()
+      appearance.configureWithTransparentBackground()
       appearance.backgroundColor = backgroundColor
       appearance.shadowColor = backgroundColor
-      navigationController?.navigationBar.tintColor = foregroundColor
       appearance.titleTextAttributes = [.foregroundColor: foregroundColor]
-
       appearance.shadowImage = UIImage()
       navigationController?.navigationBar.standardAppearance = appearance
       navigationController?.navigationBar.compactAppearance = appearance
       navigationController?.navigationBar.scrollEdgeAppearance = appearance
+    } else {
+      navigationController?.navigationBar.backgroundColor = backgroundColor
+      navigationController?.navigationBar.barTintColor = backgroundColor
+      navigationController?.navigationBar.shadowImage = UIImage()
+      navigationController?.navigationBar.titleTextAttributes = [ .foregroundColor: foregroundColor]
+      navigationController?.navigationBar.isTranslucent = true
     }
 
     navigationController?.setNeedsStatusBarAppearanceUpdate()


### PR DESCRIPTION
Fix: When Billing form screen is scrolled, the navigation bar background color is changed.
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
