### PR TITLE
Release 4.0.4: Pass UserCancelled in completion handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Released on 2022-12-21
 
 Updates
 - Mapped the `scheme_local` property from the /tokens endpoint via the SDK
+- Passing new error type `userCancelled` in completion handler for tokenisation journey
 
 ## [4.0.3](https://github.com/checkout/frames-ios/releases/tag/4.0.3)
 

--- a/Checkout/Checkout/Source/Tokenisation/Error/TokenisationError+TokenRequest.swift
+++ b/Checkout/Checkout/Source/Tokenisation/Error/TokenisationError+TokenRequest.swift
@@ -11,6 +11,7 @@ extension TokenisationError {
   public enum TokenRequest: CheckoutError {
     case couldNotBuildURLForRequest
     case applePayTokenInvalid
+    case userCancelled
     case cardValidationError(ValidationError.Card)
     case networkError(NetworkError)
     case serverError(ServerError)
@@ -21,6 +22,8 @@ extension TokenisationError {
         return 3001
       case .applePayTokenInvalid:
         return 1100
+      case .userCancelled:
+        return 0
       case .cardValidationError(let cardValidationError):
         return cardValidationError.code
       case .networkError(let networkError):

--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -55,6 +55,7 @@ class DefaultPaymentViewModel: PaymentViewModel {
 
     func viewControllerCancelled() {
         logger.log(.paymentFormCanceled)
+        cardTokenRequested?(.failure(.userCancelled))
     }
 
     func updateAll() {

--- a/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -699,6 +699,20 @@ final class PaymentViewModelTests: XCTestCase {
         XCTAssertEqual(fakeLogger.logCalledWithFramesLogEvents, [.paymentFormSubmitted, .warn(message: expectedWarnMessage)])
     }
     
+    func testPressCancelTriggerCompletionHandler() {
+        let model = makeViewModel()
+        let expect = expectation(description: "Should call completion handler")
+        
+        model.cardTokenRequested = {
+            expect.fulfill()
+            XCTAssertEqual($0, .failure(.userCancelled))
+        }
+        
+        model.viewControllerCancelled()
+        
+        waitForExpectations(timeout: 0.1)
+    }
+    
     func testBillingTapDoneCallback() {
         let testLogger = StubFramesEventLogger()
         let model = makeViewModel(logger: testLogger)


### PR DESCRIPTION
## Proposed changes

By passing the cancellation as an error of `userCancelled`, the consumer can successfully track the occurrence of this event.

Will require product review and internal discussion over possible alternatives that may fit better into the product roadmap.

