### PR TITLE
Release 4.0.4: Do not parse network response for scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All notable changes to this project will be documented in this file.
 
 ## [4.0.4](https://github.com/checkout/frames-ios/releases/tag/4.0.4)
 
-Released on 2022-12-21
+Released on 2023-01-04
 
-Updates
-- Mapped the `scheme_local` property from the /tokens endpoint via the SDK
+Updates:
+
+- Mapped the `scheme_local` property from the /tokens endpoint via the SDK (NAS keys only)
+- Handles cartes_bancaires and mada strings in `scheme` property returned from /tokens endpoint
 - Passing new error type `userCancelled` in completion handler for tokenisation journey
 
 ## [4.0.3](https://github.com/checkout/frames-ios/releases/tag/4.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## [4.0.4](https://github.com/checkout/frames-ios/releases/tag/4.0.4)
 
-Released on 2023-01-04
+Released on 2023-01-05
 
 Updates:
 

--- a/Checkout/Checkout/Source/Model/TokenDetails.swift
+++ b/Checkout/Checkout/Source/Model/TokenDetails.swift
@@ -13,7 +13,7 @@ public struct TokenDetails: Equatable {
   public let token: String
   public let expiresOn: String
   public let expiryDate: ExpiryDate
-  public let scheme: Card.Scheme?
+  public let scheme: String?
   public let schemeLocal: String?
   public let last4: String
   public let bin: String

--- a/Checkout/Checkout/Source/Tokenisation/TokenDetailsFactory.swift
+++ b/Checkout/Checkout/Source/Tokenisation/TokenDetailsFactory.swift
@@ -18,7 +18,7 @@ final class TokenDetailsFactory: TokenDetailsProviding {
       token: tokenResponse.token,
       expiresOn: tokenResponse.expiresOn,
       expiryDate: create(expiryMonth: tokenResponse.expiryMonth, expiryYear: tokenResponse.expiryYear),
-      scheme: tokenResponse.scheme.flatMap({ Card.Scheme(rawValue: $0) }),
+      scheme: tokenResponse.scheme,
       schemeLocal: tokenResponse.schemeLocal,
       last4: tokenResponse.last4,
       bin: tokenResponse.bin,

--- a/Checkout/Sample/Source/Card Tokenisation/CardTokenizationViewController.swift
+++ b/Checkout/Sample/Source/Card Tokenisation/CardTokenizationViewController.swift
@@ -122,7 +122,7 @@ class CardTokenizationViewController: UIViewController {
       phone: phone)
 
     let checkoutAPIService = CheckoutAPIService(
-      publicKey: "pk_sbox_4zwxstydpp7tytwedivr75oiyie",
+      publicKey: "pk_sbox_ym4kqv5lzvjni7utqbliqs2vhqc",
       environment: .sandbox)
     checkoutAPIService.createToken(.card(card)) { result in
       switch result {

--- a/Checkout/Sample/Source/Card Tokenisation/CardTokenizationViewController.swift
+++ b/Checkout/Sample/Source/Card Tokenisation/CardTokenizationViewController.swift
@@ -122,7 +122,7 @@ class CardTokenizationViewController: UIViewController {
       phone: phone)
 
     let checkoutAPIService = CheckoutAPIService(
-      publicKey: "pk_test_6e40a700-d563-43cd-89d0-f9bb17d35e73",
+      publicKey: "pk_sbox_4zwxstydpp7tytwedivr75oiyie",
       environment: .sandbox)
     checkoutAPIService.createToken(.card(card)) { result in
       switch result {

--- a/CheckoutTests/Integration/CheckoutAPIServiceIntegrationTests.swift
+++ b/CheckoutTests/Integration/CheckoutAPIServiceIntegrationTests.swift
@@ -107,7 +107,7 @@ final class CheckoutAPIServiceIntegrationTests: XCTestCase {
 
     XCTAssertEqual(
       tokenDetails.scheme,
-      try! CardValidator(environment: .sandbox).validate(cardNumber: card.number).get()
+      try! CardValidator(environment: .sandbox).validate(cardNumber: card.number).get().rawValue
     )
 
     let last4digits = "4242"
@@ -145,7 +145,7 @@ final class CheckoutAPIServiceIntegrationTests: XCTestCase {
         XCTAssertNil(tokenDetails.phone)
         XCTAssertEqual(tokenDetails.productId, "MDW")
         XCTAssertEqual(tokenDetails.productType, "MDW - (World Elite™ Debit MasterCard®)")
-        XCTAssertEqual(tokenDetails.scheme, .mastercard)
+        XCTAssertEqual(tokenDetails.scheme, "Mastercard")
         XCTAssertNil(tokenDetails.name)
     }
 

--- a/CheckoutTests/Integration/CheckoutAPIServiceIntegrationTests.swift
+++ b/CheckoutTests/Integration/CheckoutAPIServiceIntegrationTests.swift
@@ -130,7 +130,6 @@ final class CheckoutAPIServiceIntegrationTests: XCTestCase {
 
     private func verifyApplePayToken(applePayDetails: ApplePayDetails, tokenDetails: TokenDetails) {
         XCTAssertEqual(tokenDetails.type, .applePay)
-        XCTAssertNotNil(ISO8601DateFormatter().date(from: tokenDetails.expiresOn))
         XCTAssertNotNil(tokenDetails.token)
         
         XCTAssertEqual(tokenDetails.expiryDate, applePayDetails.expiryDate)
@@ -138,14 +137,14 @@ final class CheckoutAPIServiceIntegrationTests: XCTestCase {
         XCTAssertEqual(tokenDetails.last4, applePayDetails.last4)
         
         XCTAssertNil(tokenDetails.billingAddress)
-        XCTAssertEqual(tokenDetails.cardCategory, "Consumer")
-        XCTAssertEqual(tokenDetails.cardType, "Debit")
+        XCTAssertEqual(tokenDetails.cardCategory, "CONSUMER")
+        XCTAssertEqual(tokenDetails.cardType, "DEBIT")
         XCTAssertEqual(tokenDetails.issuer, "CURVE UK LIMITED")
         XCTAssertEqual(tokenDetails.issuerCountry, "GB")
         XCTAssertNil(tokenDetails.phone)
         XCTAssertEqual(tokenDetails.productId, "MDW")
         XCTAssertEqual(tokenDetails.productType, "MDW - (World Elite™ Debit MasterCard®)")
-        XCTAssertEqual(tokenDetails.scheme, "Mastercard")
+        XCTAssertEqual(tokenDetails.scheme, "MASTERCARD")
         XCTAssertNil(tokenDetails.name)
     }
 

--- a/CheckoutTests/Integration/CheckoutAPIServiceIntegrationTests.swift
+++ b/CheckoutTests/Integration/CheckoutAPIServiceIntegrationTests.swift
@@ -15,7 +15,7 @@ final class CheckoutAPIServiceIntegrationTests: XCTestCase {
   override func setUp() {
     super.setUp()
 
-    subject = CheckoutAPIService(publicKey: "pk_test_6e40a700-d563-43cd-89d0-f9bb17d35e73", environment: .sandbox)
+    subject = CheckoutAPIService(publicKey: "pk_sbox_ym4kqv5lzvjni7utqbliqs2vhqc", environment: .sandbox)
   }
 
   override func tearDown() {

--- a/CheckoutTests/Stubs/StubProvider.swift
+++ b/CheckoutTests/Stubs/StubProvider.swift
@@ -151,7 +151,7 @@ enum StubProvider {
     token: String = "token",
     expiresOn: String = "expiresOn",
     expiryDate: ExpiryDate = try! CardValidator(environment: .sandbox).validate(expiryMonth: 5, expiryYear: 50).get(),
-    scheme: Card.Scheme? = .visa,
+    scheme: String? = "visa",
     schemeLocal: String? = nil,
     last4: String = "4242",
     bin: String = "424242",

--- a/CheckoutTests/Tokenisation/TokenDetailsFactoryTests.swift
+++ b/CheckoutTests/Tokenisation/TokenDetailsFactoryTests.swift
@@ -63,7 +63,7 @@ final class TokenDetailsFactoryTests: XCTestCase {
         XCTAssertEqual(publicToken.token, testToken)
         XCTAssertEqual(publicToken.expiresOn, testExpiresOn)
         XCTAssertEqual(publicToken.expiryDate, ExpiryDate(month: testExpiryMonth, year: testExpiryYear))
-        XCTAssertEqual(publicToken.scheme, .visa)
+        XCTAssertEqual(publicToken.scheme, "visa")
         XCTAssertEqual(publicToken.schemeLocal, testSchemeLocal)
         XCTAssertEqual(publicToken.last4, testLast4)
         XCTAssertEqual(publicToken.bin, testBin)

--- a/Tests/Mocks/StubCheckoutAPIService.swift
+++ b/Tests/Mocks/StubCheckoutAPIService.swift
@@ -45,7 +45,7 @@ extension StubCheckoutAPIService {
     token: String = "token",
     expiresOn: String = "expiresOn",
     expiryDate: ExpiryDate = try! CardValidator(environment: .sandbox).validate(expiryMonth: 5, expiryYear: 50).get(),
-    scheme: Card.Scheme? = .visa,
+    scheme: String? = "visa",
     schemeLocal: String? = nil,
     last4: String = "4242",
     bin: String = "424242",

--- a/iOS Example Apple Pay/iOS Example Apple Pay/ViewController.swift
+++ b/iOS Example Apple Pay/iOS Example Apple Pay/ViewController.swift
@@ -12,7 +12,7 @@ PKPaymentAuthorizationViewControllerDelegate {
     @IBOutlet weak var payButtonsView: UIStackView!
     var cardsTableViewHeightConstraint: NSLayoutConstraint?
     
-    let publicKey = "pk_test_03728582-062b-419c-91b5-63ac2a481e07"
+    let publicKey = "pk_sbox_ym4kqv5lzvjni7utqbliqs2vhqc"
     var checkoutAPIClient: CheckoutAPIClient { return CheckoutAPIClient(publicKey: publicKey, environment: .sandbox) }
     let cardUtils = CardUtils()
     var availableSchemes: [CardScheme] = []

--- a/iOS Example Frame/iOS Example Frame/Factory/Factory.swift
+++ b/iOS Example Frame/iOS Example Frame/Factory/Factory.swift
@@ -15,7 +15,7 @@ enum Factory {
   static let successURL = URL(string: "https://httpstat.us/200")!
     // swiftlint:disable:next force_unwrapping
   static let failureURL = URL(string: "https://httpstat.us/403")!
-  static let apiKey = "pk_sbox_4zwxstydpp7tytwedivr75oiyie"
+  static let apiKey = "pk_sbox_ym4kqv5lzvjni7utqbliqs2vhqc"
   static let environment: Frames.Environment = .sandbox
 
   static func getDefaultPaymentViewController(completionHandler: @escaping (Result<TokenDetails, TokenRequestError>) -> Void) -> UIViewController {

--- a/iOS Example Frame/iOS Example Frame/Factory/Factory.swift
+++ b/iOS Example Frame/iOS Example Frame/Factory/Factory.swift
@@ -15,7 +15,7 @@ enum Factory {
   static let successURL = URL(string: "https://httpstat.us/200")!
     // swiftlint:disable:next force_unwrapping
   static let failureURL = URL(string: "https://httpstat.us/403")!
-  static let apiKey = "pk_test_6e40a700-d563-43cd-89d0-f9bb17d35e73"
+  static let apiKey = "pk_sbox_4zwxstydpp7tytwedivr75oiyie"
   static let environment: Frames.Environment = .sandbox
 
   static func getDefaultPaymentViewController(completionHandler: @escaping (Result<TokenDetails, TokenRequestError>) -> Void) -> UIViewController {

--- a/iOS Example/iOS Example/ExampleViewController.swift
+++ b/iOS Example/iOS Example/ExampleViewController.swift
@@ -24,7 +24,7 @@ class ExampleViewController: UIViewController,
 
     @IBOutlet weak var cardsTableView: UITableView!
 
-    let publicKey = "pk_test_03728582-062b-419c-91b5-63ac2a481e07"
+    let publicKey = "pk_sbox_ym4kqv5lzvjni7utqbliqs2vhqc"
     var checkoutAPIClient: CheckoutAPIClient { return CheckoutAPIClient(publicKey: publicKey, environment: .sandbox) }
     var availableSchemes: [CardScheme] = []
 


### PR DESCRIPTION
## Proposed changes

As schemes may come and go, removing the enum parsing in the object will future proof SDK support. This enables consumers (going as far as end mobile application), to recognise tokens created by new card schemes without the need to getting the latest SDK version.