### PR TITLE
PIMOB-1972: Add new error type for missing API Key

### DIFF
--- a/Checkout/Checkout/Source/Tokenisation/CheckoutAPIService.swift
+++ b/Checkout/Checkout/Source/Tokenisation/CheckoutAPIService.swift
@@ -79,6 +79,10 @@ final public class CheckoutAPIService: CheckoutAPIProtocol {
 
 /// The create token method tokenises the user’s card details.
   public func createToken(_ paymentSource: PaymentSource, completion: @escaping (Result<TokenDetails, TokenisationError.TokenRequest>) -> Void) {
+      guard !publicKey.isEmpty else {
+          completion(.failure(.missingAPIKey))
+          return
+      }
     let tokenRequestResult = tokenRequestFactory.create(paymentSource: paymentSource)
 
     switch tokenRequestResult {

--- a/Checkout/Checkout/Source/Tokenisation/Error/TokenisationError+TokenRequest.swift
+++ b/Checkout/Checkout/Source/Tokenisation/Error/TokenisationError+TokenRequest.swift
@@ -12,6 +12,7 @@ extension TokenisationError {
     case couldNotBuildURLForRequest
     case applePayTokenInvalid
     case userCancelled
+    case missingAPIKey
     case cardValidationError(ValidationError.Card)
     case networkError(NetworkError)
     case serverError(ServerError)
@@ -24,6 +25,8 @@ extension TokenisationError {
         return 1100
       case .userCancelled:
         return 0
+      case .missingAPIKey:
+          return 4000
       case .cardValidationError(let cardValidationError):
         return cardValidationError.code
       case .networkError(let networkError):

--- a/CheckoutTests/CheckoutErrorTests.swift
+++ b/CheckoutTests/CheckoutErrorTests.swift
@@ -56,6 +56,8 @@ final class CheckoutErrorTests: XCTestCase {
 
     XCTAssertEqual(TokenisationError.TokenRequest.serverError(serverError).code, 3000)
     XCTAssertEqual(TokenisationError.TokenRequest.couldNotBuildURLForRequest.code, 3001)
+      
+    XCTAssertEqual(TokenisationError.TokenRequest.missingAPIKey.code, 4000)
 
     XCTAssertEqual(
       TokenisationError.TokenRequest.cardValidationError(.phone(randomPhoneError)).code,

--- a/CheckoutTests/Tokenisation/CheckoutAPIServiceTests.swift
+++ b/CheckoutTests/Tokenisation/CheckoutAPIServiceTests.swift
@@ -182,16 +182,13 @@ final class CheckoutAPIServiceTests: XCTestCase {
         let service = CheckoutAPIService(publicKey: "", environment: .sandbox)
         let testCard = StubProvider.createCard()
         
-        let expect = expectation(description: "Waiting for possible multithreaded behaviour")
         service.createToken(.card(testCard)) { result in
-            expect.fulfill()
             if case .failure(let failure) = result {
                 XCTAssertEqual(failure, .missingAPIKey)
             } else {
                 XCTFail("Test should return a failure")
             }
         }
-        waitForExpectations(timeout: 0.5)
     }
 
   // MARK: correlationID

--- a/CheckoutTests/Tokenisation/CheckoutAPIServiceTests.swift
+++ b/CheckoutTests/Tokenisation/CheckoutAPIServiceTests.swift
@@ -177,6 +177,22 @@ final class CheckoutAPIServiceTests: XCTestCase {
 
     XCTAssertEqual(result, .failure(.networkError(.connectionFailed)))
   }
+    
+    func testCreateTokenWithoutAPIKey() {
+        let service = CheckoutAPIService(publicKey: "", environment: .sandbox)
+        let testCard = StubProvider.createCard()
+        
+        let expect = expectation(description: "Waiting for possible multithreaded behaviour")
+        service.createToken(.card(testCard)) { result in
+            expect.fulfill()
+            if case .failure(let failure) = result {
+                XCTAssertEqual(failure, .missingAPIKey)
+            } else {
+                XCTFail("Test should return a failure")
+            }
+        }
+        waitForExpectations(timeout: 0.5)
+    }
 
   // MARK: correlationID
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,9 @@ let package = Package(
         .target(
             name: "Frames",
             dependencies: [
+                .product(name: "CheckoutEventLoggerKit",
+                         package: "checkout-event-logger-ios-framework"),
                 "PhoneNumberKit",
-                "CheckoutEventLoggerKit",
                 "Checkout"
             ],
             path: "Source",
@@ -40,7 +41,8 @@ let package = Package(
         .target(
             name: "Checkout",
             dependencies: [
-                "CheckoutEventLoggerKit",
+                .product(name: "CheckoutEventLoggerKit",
+                         package: "checkout-event-logger-ios-framework"),
             ],
             path: "Checkout/Checkout/Source"
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -16,12 +16,9 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            name: "PhoneNumberKit",
             url: "https://github.com/marmelroy/PhoneNumberKit.git",
-            from: "3.5.9"
-        ),
+            exact: "3.5.9"),
         .package(
-            name: "CheckoutEventLoggerKit",
             url: "https://github.com/checkout/checkout-event-logger-ios-framework.git",
             from: "1.2.4"
         )

--- a/Source/Extensions/PhoneExtensions.swift
+++ b/Source/Extensions/PhoneExtensions.swift
@@ -24,7 +24,7 @@ extension Phone {
         if number?.starts(with: "+") == true {
             return PhoneNumberValidator.shared.formatForDisplay(text: number ?? "")
         } else {
-            return PhoneNumberValidator.shared.formatForDisplay(text: "\(country?.dialingCode ?? "")\(number ?? "")")
+            return PhoneNumberValidator.shared.formatForDisplay(text: "+\(country?.dialingCode ?? "")\(number ?? "")")
         }
     }
 

--- a/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
+++ b/Tests/UI/BillingForm/ViewModel/PaymentViewModelTests.swift
@@ -13,7 +13,7 @@ final class PaymentViewModelTests: XCTestCase {
                                               address: Address(addressLine1: "home", addressLine2: "sleeping", city: "rough night", state: "tired", zip: "Zzzz", country: nil),
                                               phone: Phone(number: "notAvailable", country: nil))
         let testSupportedSchemes: [Card.Scheme] = [.discover, .mada]
-        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "casgrs", environment: Environment.sandbox)
 
         let viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                                 cardValidator: testCardValidator,
@@ -73,7 +73,7 @@ final class PaymentViewModelTests: XCTestCase {
     
     func testOnBillingScreenShownSendsEventToLogger() {
         let testLogger = StubFramesEventLogger()
-        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "cvvb", environment: Environment.sandbox)
         let viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                                 cardValidator: CardValidator(environment: .sandbox),
                                                 logger: testLogger,
@@ -93,7 +93,7 @@ final class PaymentViewModelTests: XCTestCase {
     }
 
     func testUpdateExpiryDateView() {
-        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "cvvb", environment: Environment.sandbox)
         viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                             cardValidator: CardValidator(environment: .sandbox),
                                             logger: StubFramesEventLogger(),
@@ -113,7 +113,7 @@ final class PaymentViewModelTests: XCTestCase {
     }
     
     func testUpdateCardholderView() {
-        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "cvvb", environment: Environment.sandbox)
         viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                             cardValidator: CardValidator(environment: .sandbox),
                                             logger: StubFramesEventLogger(),
@@ -135,7 +135,7 @@ final class PaymentViewModelTests: XCTestCase {
     }
 
     func testUpdateAddBillingSummaryView() {
-        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "cvvb", environment: Environment.sandbox)
         viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                             cardValidator: CardValidator(environment: .sandbox),
                                             logger: StubFramesEventLogger(),
@@ -167,7 +167,7 @@ final class PaymentViewModelTests: XCTestCase {
         let billingFormData = BillingForm(name: userName,
                                           address: address,
                                           phone: phone)
-        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "cvvb", environment: Environment.sandbox)
         viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService, cardValidator: CardValidator(environment: .sandbox),
                                             logger: StubFramesEventLogger(),
                                             billingFormData: billingFormData,
@@ -191,7 +191,7 @@ final class PaymentViewModelTests: XCTestCase {
         let billingFormData = BillingForm(name: userName,
                                           address: nil,
                                           phone: phone)
-        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "cvvb", environment: Environment.sandbox)
         viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService,
                                             cardValidator: CardValidator(environment: .sandbox),
                                             logger: StubFramesEventLogger(),
@@ -222,7 +222,7 @@ final class PaymentViewModelTests: XCTestCase {
         let billingFormData = BillingForm(name: userName,
                                           address: address,
                                           phone: phone)
-        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "", environment: Environment.sandbox)
+        let checkoutAPIService = Frames.CheckoutAPIService(publicKey: "cvvb", environment: Environment.sandbox)
         viewModel = DefaultPaymentViewModel(checkoutAPIService: checkoutAPIService, cardValidator: CardValidator(environment: .sandbox),
                                             logger: StubFramesEventLogger(),
                                             billingFormData: billingFormData,

--- a/iOS Example Frame/iOS Example Frame/ViewController/HomeViewController.swift
+++ b/iOS Example Frame/iOS Example Frame/ViewController/HomeViewController.swift
@@ -137,6 +137,8 @@ class HomeViewController: UIViewController {
                 showAlert(with: "Error code: \(serverError.code)", title: "Server Error")
             case .couldNotBuildURLForRequest:
                 showAlert(with: "Error code: \(failure.code)", title: "Could Not Build URL")
+            case .missingAPIKey:
+                showAlert(with: "You need to make sure an API key is present", title: "Missing API Key")
             }
         case .success(let tokenDetails):
             showAlert(with: tokenDetails.token, title: "Success")


### PR DESCRIPTION
[PIMOB-1972](https://checkout.atlassian.net/browse/PIMOB-1972)

Create new error and return when tokenisation is attempted and an API Key does not exist.

❌ Change **does not** perform validation on the key! It simply validates that a value is provided
✔️ New error will get reported within the current analytics flows


*** 

🔴 This is an API breaking change, but is also auto corrected by using Xcode. The break only appears if consumer application is using a switch statement to iterate via errors returned by SDK. Xcode can however autoupdate the syntax to include the new `case`, making it a minor hurdle to overcome.

🟡 We may reduce impact of the breaking change if we move the error within `NetworkError`, where it will only break if the consumer application uses a switch statement on the `TokenRequestError.NetworkError` (1 layer inside the current proposed layer). 
This would however place error inside the wrong layer, as the validation is done locally and it is not technically a NetworkError. Also, it will still break the API in the exact same way, but for a smaller subset.

[PIMOB-1972]: https://checkout.atlassian.net/browse/PIMOB-1972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

*** 

Sample application example

![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-09 at 10 13 20](https://github.com/checkout/frames-ios/assets/102028170/eeaf17e6-6be0-40e5-9867-b144923390cc)
