### PR TITLE
PIMOB-2011: Avoid breaking API for borders release

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -62,5 +62,7 @@ line_length:
      ignores_urls: true
 
 identifier_name:
+  allowed_symbols:
+    - "_"
   excluded:
     - id

--- a/Source/Extensions/CAShapeLayerExtension.swift
+++ b/Source/Extensions/CAShapeLayerExtension.swift
@@ -25,6 +25,13 @@ extension CAShapeLayer {
         self.path = path.cgPath
     }
 
+    func createBackground(with style: ElementBorderStyle) {
+        let path = UIBezierPath(roundedRect: frame,
+                                byRoundingCorners: style.corners ?? [],
+                                cornerRadii: CGSize(width: style.cornerRadius, height: style.cornerRadius))
+        self.path = path.cgPath
+    }
+
     /*
      (0,0)  c-----------c  (100,0)
             |           |

--- a/Source/UI/BillingForm/Default Implementation/BillingForm/Header/Cancel/DefaultCancelButtonFormStyle.swift
+++ b/Source/UI/BillingForm/Default Implementation/BillingForm/Header/Cancel/DefaultCancelButtonFormStyle.swift
@@ -16,9 +16,48 @@ public struct DefaultCancelButtonFormStyle: ElementButtonStyle {
     public var height: Double = Constants.Style.BillingForm.CancelButton.height.rawValue
     public var width: Double = Constants.Style.BillingForm.CancelButton.width.rawValue
     public var textLeading: CGFloat = 0
-    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(cornerRadius: 0,
-                                                                   borderWidth: 0,
-                                                                   normalColor: .clear,
-                                                                   focusColor: .clear,
-                                                                   errorColor: .clear)
+
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+    public var cornerRadius: CGFloat {
+        get { _cornerRadius }
+        set { _cornerRadius = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
+    public var borderWidth: CGFloat {
+        get { _borderWidth }
+        set { _borderWidth = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
+    public var normalBorderColor: UIColor {
+        get { _normalBorderColor }
+        set { _normalBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.focusColor")
+    public var focusBorderColor: UIColor {
+        get { _focusBorderColor }
+        set { _focusBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.errorColor")
+    public var errorBorderColor: UIColor {
+        get { _errorBorderColor }
+        set { _errorBorderColor = newValue }
+    }
+
+    internal var _cornerRadius: CGFloat = 0
+    internal var _borderWidth: CGFloat = 0
+    internal var _normalBorderColor: UIColor = .clear
+    internal var _focusBorderColor: UIColor = .clear
+    internal var _errorBorderColor: UIColor = .clear
+
+    public lazy var borderStyle: ElementBorderStyle = {
+        DefaultBorderStyle(cornerRadius: _cornerRadius,
+                           borderWidth: _borderWidth,
+                           normalColor: _normalBorderColor,
+                           focusColor: _focusBorderColor,
+                           errorColor: _errorBorderColor)
+    }()
 }

--- a/Source/UI/BillingForm/Default Implementation/BillingForm/Header/Done/DefaultDoneFormButtonStyle.swift
+++ b/Source/UI/BillingForm/Default Implementation/BillingForm/Header/Done/DefaultDoneFormButtonStyle.swift
@@ -16,9 +16,49 @@ public struct DefaultDoneFormButtonStyle: ElementButtonStyle {
     public var height: Double = Constants.Style.BillingForm.DoneButton.height.rawValue
     public var width: Double = Constants.Style.BillingForm.DoneButton.width.rawValue
     public var textLeading: CGFloat = 0
-    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(cornerRadius: 0,
-                                                                   borderWidth: 0,
-                                                                   normalColor: .clear,
-                                                                   focusColor: .clear,
-                                                                   errorColor: .clear)
+
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+    public var cornerRadius: CGFloat {
+        get { _cornerRadius }
+        set { _cornerRadius = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
+    public var borderWidth: CGFloat {
+        get { _borderWidth }
+        set { _borderWidth = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
+    public var normalBorderColor: UIColor {
+        get { _normalBorderColor }
+        set { _normalBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.focusColor")
+    public var focusBorderColor: UIColor {
+        get { _focusBorderColor }
+        set { _focusBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.errorColor")
+    public var errorBorderColor: UIColor {
+        get { _errorBorderColor }
+        set { _errorBorderColor = newValue }
+    }
+
+    internal var _cornerRadius: CGFloat = 0
+    internal var _borderWidth: CGFloat = 0
+    internal var _normalBorderColor: UIColor = .clear
+    internal var _focusBorderColor: UIColor = .clear
+    internal var _errorBorderColor: UIColor = .clear
+
+    public lazy var borderStyle: ElementBorderStyle = {
+        DefaultBorderStyle(cornerRadius: _cornerRadius,
+                           borderWidth: _borderWidth,
+                           normalColor: _normalBorderColor,
+                           focusColor: _focusBorderColor,
+                           errorColor: _errorBorderColor)
+    }()
+
 }

--- a/Source/UI/BillingForm/Default Implementation/Elements/Country/DefaultCountryFormButtonStyle.swift
+++ b/Source/UI/BillingForm/Default Implementation/Elements/Country/DefaultCountryFormButtonStyle.swift
@@ -16,5 +16,48 @@ public struct DefaultCountryFormButtonStyle: ElementButtonStyle {
     public var textLeading: CGFloat = Constants.Style.BillingForm.InputCountryButton.textLeading.rawValue
     public var height: Double = Constants.Style.BillingForm.InputCountryButton.height.rawValue
     public var width: Double = Constants.Style.BillingForm.InputCountryButton.width.rawValue
-    public var borderStyle: ElementBorderStyle = DefaultBorderStyle()
+
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+    public var cornerRadius: CGFloat {
+        get { _cornerRadius }
+        set { _cornerRadius = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
+    public var borderWidth: CGFloat {
+        get { _borderWidth }
+        set { _borderWidth = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
+    public var normalBorderColor: UIColor {
+        get { _normalBorderColor }
+        set { _normalBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.focusColor")
+    public var focusBorderColor: UIColor {
+        get { _focusBorderColor }
+        set { _focusBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.errorColor")
+    public var errorBorderColor: UIColor {
+        get { _errorBorderColor }
+        set { _errorBorderColor = newValue }
+    }
+
+    internal var _cornerRadius: CGFloat = Constants.Style.BorderStyle.cornerRadius
+    internal var _borderWidth: CGFloat = Constants.Style.BorderStyle.borderWidth
+    internal var _normalBorderColor: UIColor = FramesUIStyle.Color.borderPrimary
+    internal var _focusBorderColor: UIColor = FramesUIStyle.Color.borderActive
+    internal var _errorBorderColor: UIColor = FramesUIStyle.Color.borderError
+
+    public lazy var borderStyle: ElementBorderStyle = {
+        DefaultBorderStyle(cornerRadius: _cornerRadius,
+                           borderWidth: _borderWidth,
+                           normalColor: _normalBorderColor,
+                           focusColor: _focusBorderColor,
+                           errorColor: _errorBorderColor)
+    }()
 }

--- a/Source/UI/BillingForm/Default Implementation/Elements/TextField/DefaultTextField.swift
+++ b/Source/UI/BillingForm/Default Implementation/Elements/TextField/DefaultTextField.swift
@@ -12,5 +12,48 @@ public struct DefaultTextField: ElementTextFieldStyle {
     public var width: Double = Constants.Style.BillingForm.InputTextField.width.rawValue
     public var height: Double = Constants.Style.BillingForm.InputTextField.height.rawValue
     public var font = FramesUIStyle.Font.inputLabel
-    public var borderStyle: ElementBorderStyle = DefaultBorderStyle()
+
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+    public var cornerRadius: CGFloat {
+        get { _cornerRadius }
+        set { _cornerRadius = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
+    public var borderWidth: CGFloat {
+        get { _borderWidth }
+        set { _borderWidth = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
+    public var normalBorderColor: UIColor {
+        get { _normalBorderColor }
+        set { _normalBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.focusColor")
+    public var focusBorderColor: UIColor {
+        get { _focusBorderColor }
+        set { _focusBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.errorColor")
+    public var errorBorderColor: UIColor {
+        get { _errorBorderColor }
+        set { _errorBorderColor = newValue }
+    }
+
+    internal var _cornerRadius: CGFloat = 10
+    internal var _borderWidth: CGFloat = 1
+    internal var _normalBorderColor: UIColor = FramesUIStyle.Color.borderPrimary
+    internal var _focusBorderColor: UIColor = FramesUIStyle.Color.borderActive
+    internal var _errorBorderColor: UIColor = FramesUIStyle.Color.borderError
+
+    public lazy var borderStyle: ElementBorderStyle = {
+        DefaultBorderStyle(cornerRadius: _cornerRadius,
+                           borderWidth: _borderWidth,
+                           normalColor: _normalBorderColor,
+                           focusColor: _focusBorderColor,
+                           errorColor: _errorBorderColor)
+    }()
 }

--- a/Source/UI/BillingForm/View/BillingFormTextFieldView.swift
+++ b/Source/UI/BillingForm/View/BillingFormTextFieldView.swift
@@ -123,7 +123,7 @@ class BillingFormTextFieldView: UIView {
         style.textfield.borderStyle.normalColor
         textFieldContainerBorder.update(with: style.textfield.borderStyle)
         textFieldContainerBorder.updateBorderColor(to: borderColor)
-        textFieldContainer.backgroundColor = style.textfield.backgroundColor
+        textFieldContainerBorder.backgroundColor = style.textfield.backgroundColor
     }
 
     private func update(textField: BillingFormTextField?, style: CellTextFieldStyle, textFieldValue: String?, tag: Int) {

--- a/Source/UI/CommonUI/Protocols/Elements/ElementBorderStyle.swift
+++ b/Source/UI/CommonUI/Protocols/Elements/ElementBorderStyle.swift
@@ -1,11 +1,11 @@
 import UIKit
 
 public protocol ElementBorderStyle {
-    var cornerRadius: CGFloat { get }
-    var borderWidth: CGFloat { get }
-    var normalColor: UIColor { get }
-    var focusColor: UIColor { get }
-    var errorColor: UIColor { get }
-    var edges: UIRectEdge? { get }
-    var corners: UIRectCorner? { get }
+    var cornerRadius: CGFloat { get set }
+    var borderWidth: CGFloat { get set }
+    var normalColor: UIColor { get set }
+    var focusColor: UIColor { get set }
+    var errorColor: UIColor { get set }
+    var edges: UIRectEdge? { get set }
+    var corners: UIRectCorner? { get set }
 }

--- a/Source/UI/CommonUI/Protocols/Elements/ElementButtonStyle.swift
+++ b/Source/UI/CommonUI/Protocols/Elements/ElementButtonStyle.swift
@@ -12,19 +12,19 @@ public protocol ElementButtonStyle: ElementStyle {
     var width: Double { get }
     var borderStyle: ElementBorderStyle { get }
 
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.cornerRadius instead")
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     var cornerRadius: CGFloat { get }
 
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.borderWidth instead")
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
     var borderWidth: CGFloat { get }
-    
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.normalColor instead")
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
     var normalBorderColor: UIColor { get }
-    
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.focusColor instead")
+
+    @available(*, deprecated, renamed: "borderStyle.focusColor")
     var focusBorderColor: UIColor { get }
-    
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.errorColor instead")
+
+    @available(*, deprecated, renamed: "borderStyle.errorColor")
     var errorBorderColor: UIColor { get }
 
 }
@@ -38,15 +38,15 @@ public extension ElementButtonStyle {
     var borderWidth: CGFloat {
         Constants.Style.BorderStyle.borderWidth
     }
-    
+
     var normalBorderColor: UIColor {
         FramesUIStyle.Color.borderPrimary
     }
-    
+
     var focusBorderColor: UIColor {
         FramesUIStyle.Color.borderActive
     }
-    
+
     var errorBorderColor: UIColor {
         FramesUIStyle.Color.borderError
     }

--- a/Source/UI/CommonUI/Protocols/Elements/ElementButtonStyle.swift
+++ b/Source/UI/CommonUI/Protocols/Elements/ElementButtonStyle.swift
@@ -17,6 +17,16 @@ public protocol ElementButtonStyle: ElementStyle {
 
     @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.borderWidth instead")
     var borderWidth: CGFloat { get }
+    
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.normalColor instead")
+    var normalBorderColor: UIColor { get }
+    
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.focusColor instead")
+    var focusBorderColor: UIColor { get }
+    
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.errorColor instead")
+    var errorBorderColor: UIColor { get }
+
 }
 
 public extension ElementButtonStyle {
@@ -28,14 +38,25 @@ public extension ElementButtonStyle {
     var borderWidth: CGFloat {
         Constants.Style.BorderStyle.borderWidth
     }
+    
+    var normalBorderColor: UIColor {
+        FramesUIStyle.Color.borderPrimary
+    }
+    
+    var focusBorderColor: UIColor {
+        FramesUIStyle.Color.borderActive
+    }
+    
+    var errorBorderColor: UIColor {
+        FramesUIStyle.Color.borderError
+    }
 
     var borderStyle: ElementBorderStyle {
-        // Deprecated warning required to encourage migrating away from using these properties
         DefaultBorderStyle(cornerRadius: cornerRadius,
                            borderWidth: borderWidth,
-                           normalColor: FramesUIStyle.Color.borderPrimary,
-                           focusColor: FramesUIStyle.Color.borderActive,
-                           errorColor: FramesUIStyle.Color.borderError,
+                           normalColor: normalBorderColor,
+                           focusColor: focusBorderColor,
+                           errorColor: errorBorderColor,
                            edges: .all,
                            corners: .allCorners)
     }

--- a/Source/UI/CommonUI/Protocols/Elements/ElementButtonStyle.swift
+++ b/Source/UI/CommonUI/Protocols/Elements/ElementButtonStyle.swift
@@ -11,4 +11,32 @@ public protocol ElementButtonStyle: ElementStyle {
     var height: Double { get }
     var width: Double { get }
     var borderStyle: ElementBorderStyle { get }
+
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.cornerRadius instead")
+    var cornerRadius: CGFloat { get }
+
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.borderWidth instead")
+    var borderWidth: CGFloat { get }
+}
+
+public extension ElementButtonStyle {
+
+    var cornerRadius: CGFloat {
+        Constants.Style.BorderStyle.cornerRadius
+    }
+
+    var borderWidth: CGFloat {
+        Constants.Style.BorderStyle.borderWidth
+    }
+
+    var borderStyle: ElementBorderStyle {
+        // Deprecated warning required to encourage migrating away from using these properties
+        DefaultBorderStyle(cornerRadius: cornerRadius,
+                           borderWidth: borderWidth,
+                           normalColor: FramesUIStyle.Color.borderPrimary,
+                           focusColor: FramesUIStyle.Color.borderActive,
+                           errorColor: FramesUIStyle.Color.borderError,
+                           edges: .all,
+                           corners: .allCorners)
+    }
 }

--- a/Source/UI/CommonUI/Protocols/Elements/ElementTextFieldStyle.swift
+++ b/Source/UI/CommonUI/Protocols/Elements/ElementTextFieldStyle.swift
@@ -6,4 +6,32 @@ public protocol ElementTextFieldStyle: ElementStyle {
     var placeholder: String? { get }
     var tintColor: UIColor { get }
     var borderStyle: ElementBorderStyle { get }
+
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.cornerRadius instead")
+    var cornerRadius: CGFloat { get }
+
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.borderWidth instead")
+    var borderWidth: CGFloat { get }
+}
+
+public extension ElementTextFieldStyle {
+
+    var cornerRadius: CGFloat {
+        Constants.Style.BorderStyle.cornerRadius
+    }
+
+    var borderWidth: CGFloat {
+        Constants.Style.BorderStyle.borderWidth
+    }
+
+    var borderStyle: ElementBorderStyle {
+        // Deprecated warning required to encourage migrating away from using these properties
+        DefaultBorderStyle(cornerRadius: cornerRadius,
+                           borderWidth: borderWidth,
+                           normalColor: FramesUIStyle.Color.borderPrimary,
+                           focusColor: FramesUIStyle.Color.borderActive,
+                           errorColor: FramesUIStyle.Color.borderError,
+                           edges: .all,
+                           corners: .allCorners)
+    }
 }

--- a/Source/UI/CommonUI/Protocols/Elements/ElementTextFieldStyle.swift
+++ b/Source/UI/CommonUI/Protocols/Elements/ElementTextFieldStyle.swift
@@ -7,19 +7,19 @@ public protocol ElementTextFieldStyle: ElementStyle {
     var tintColor: UIColor { get }
     var borderStyle: ElementBorderStyle { get }
 
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.cornerRadius instead")
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     var cornerRadius: CGFloat { get }
 
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.borderWidth instead")
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
     var borderWidth: CGFloat { get }
-    
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.normalColor instead")
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
     var normalBorderColor: UIColor { get }
-    
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.focusColor instead")
+
+    @available(*, deprecated, renamed: "borderStyle.focusColor")
     var focusBorderColor: UIColor { get }
-    
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.errorColor instead")
+
+    @available(*, deprecated, renamed: "borderStyle.errorColor")
     var errorBorderColor: UIColor { get }
 }
 
@@ -32,15 +32,15 @@ public extension ElementTextFieldStyle {
     var borderWidth: CGFloat {
         Constants.Style.BorderStyle.borderWidth
     }
-    
+
     var normalBorderColor: UIColor {
         FramesUIStyle.Color.borderPrimary
     }
-    
+
     var focusBorderColor: UIColor {
         FramesUIStyle.Color.borderActive
     }
-    
+
     var errorBorderColor: UIColor {
         FramesUIStyle.Color.borderError
     }

--- a/Source/UI/CommonUI/Protocols/Elements/ElementTextFieldStyle.swift
+++ b/Source/UI/CommonUI/Protocols/Elements/ElementTextFieldStyle.swift
@@ -12,6 +12,15 @@ public protocol ElementTextFieldStyle: ElementStyle {
 
     @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.borderWidth instead")
     var borderWidth: CGFloat { get }
+    
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.normalColor instead")
+    var normalBorderColor: UIColor { get }
+    
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.focusColor instead")
+    var focusBorderColor: UIColor { get }
+    
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.errorColor instead")
+    var errorBorderColor: UIColor { get }
 }
 
 public extension ElementTextFieldStyle {
@@ -23,14 +32,25 @@ public extension ElementTextFieldStyle {
     var borderWidth: CGFloat {
         Constants.Style.BorderStyle.borderWidth
     }
+    
+    var normalBorderColor: UIColor {
+        FramesUIStyle.Color.borderPrimary
+    }
+    
+    var focusBorderColor: UIColor {
+        FramesUIStyle.Color.borderActive
+    }
+    
+    var errorBorderColor: UIColor {
+        FramesUIStyle.Color.borderError
+    }
 
     var borderStyle: ElementBorderStyle {
-        // Deprecated warning required to encourage migrating away from using these properties
         DefaultBorderStyle(cornerRadius: cornerRadius,
                            borderWidth: borderWidth,
-                           normalColor: FramesUIStyle.Color.borderPrimary,
-                           focusColor: FramesUIStyle.Color.borderActive,
-                           errorColor: FramesUIStyle.Color.borderError,
+                           normalColor: normalBorderColor,
+                           focusColor: focusBorderColor,
+                           errorColor: errorBorderColor,
                            edges: .all,
                            corners: .allCorners)
     }

--- a/Source/UI/CommonUI/View/Component/BorderView.swift
+++ b/Source/UI/CommonUI/View/Component/BorderView.swift
@@ -6,9 +6,18 @@ final class BorderView: UIView {
 
     /// shaper layer that draw edges and corners
     private var borderLayer = CAShapeLayer()
+    private var backgroundLayer = CAShapeLayer()
+
+    override var backgroundColor: UIColor? {
+        get { UIColor(cgColor: backgroundLayer.backgroundColor ?? UIColor.clear.cgColor) }
+        set {
+            backgroundLayer.fillColor = newValue?.cgColor
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        layer.addSublayer(backgroundLayer)
         layer.addSublayer(borderLayer)
         backgroundColor = .clear
     }
@@ -16,8 +25,10 @@ final class BorderView: UIView {
     // Keep border layer size in sync with owning view
     override func layoutSubviews() {
         super.layoutSubviews()
+        backgroundLayer.frame = bounds
         borderLayer.frame = bounds
         guard let style = style else { return }
+        backgroundLayer.createBackground(with: style)
         borderLayer.createCustomBorder(with: style)
     }
 

--- a/Source/UI/CommonUI/View/Component/InputView.swift
+++ b/Source/UI/CommonUI/View/Component/InputView.swift
@@ -114,6 +114,7 @@ class InputView: UIView {
         textFieldContainerBorder.update(with: style.textfield.borderStyle)
         textFieldContainerBorder.updateBorderColor(to: borderColor)
         textFieldContainerBorder.backgroundColor = style.textfield.backgroundColor
+        textFieldContainerBorder.setNeedsLayout()
     }
 
     private func updateTextFieldContainer(image: UIImage?, animated: Bool) {

--- a/Source/UI/CommonUI/View/Core/ButtonView.swift
+++ b/Source/UI/CommonUI/View/Core/ButtonView.swift
@@ -61,7 +61,6 @@ class ButtonView: UIView {
 
     func update(with style: ElementButtonStyle) {
         self.style = style
-        backgroundColor = style.backgroundColor
         clipsToBounds = true
         borderView.update(with: style.borderStyle)
         borderView.updateBorderColor(to: style.borderStyle.normalColor)
@@ -74,7 +73,7 @@ class ButtonView: UIView {
     }
 
     private func updateButtonStyle(with style: ElementButtonStyle) {
-        backgroundColor = isEnabled ? style.backgroundColor : style.disabledTintColor
+        borderView.backgroundColor = isEnabled ? style.backgroundColor : style.disabledTintColor
         button.tintColor = .clear
         button.heightAnchor.constraint(equalToConstant: style.height).isActive = true
         button.accessibilityIdentifier = style.text

--- a/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/Button/DefaultAddBillingDetailsButtonStyle.swift
+++ b/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/Button/DefaultAddBillingDetailsButtonStyle.swift
@@ -16,5 +16,49 @@ public final class DefaultAddBillingDetailsButtonStyle: ElementButtonStyle {
     public var height: Double = Constants.Style.PaymentForm.InputBillingFormButton.height.rawValue
     public var width: Double = Constants.Style.PaymentForm.InputBillingFormButton.width.rawValue
     public var textLeading: CGFloat = Constants.Style.PaymentForm.InputBillingFormButton.textLeading.rawValue
-    public var borderStyle: ElementBorderStyle = DefaultBorderStyle()
+
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+    public var cornerRadius: CGFloat {
+        get { _cornerRadius }
+        set { _cornerRadius = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
+    public var borderWidth: CGFloat {
+        get { _borderWidth }
+        set { _borderWidth = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
+    public var normalBorderColor: UIColor {
+        get { _normalBorderColor }
+        set { _normalBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.focusColor")
+    public var focusBorderColor: UIColor {
+        get { _focusBorderColor }
+        set { _focusBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.errorColor")
+    public var errorBorderColor: UIColor {
+        get { _errorBorderColor }
+        set { _errorBorderColor = newValue }
+    }
+
+    internal var _cornerRadius: CGFloat = Constants.Style.BorderStyle.cornerRadius
+    internal var _borderWidth: CGFloat = Constants.Style.BorderStyle.borderWidth
+    internal var _normalBorderColor: UIColor = FramesUIStyle.Color.borderActive
+    internal var _focusBorderColor: UIColor = FramesUIStyle.Color.borderActive
+    internal var _errorBorderColor: UIColor = FramesUIStyle.Color.borderError
+
+    public lazy var borderStyle: ElementBorderStyle = {
+        DefaultBorderStyle(cornerRadius: _cornerRadius,
+                           borderWidth: _borderWidth,
+                           normalColor: _normalBorderColor,
+                           focusColor: _focusBorderColor,
+                           errorColor: _errorBorderColor)
+    }()
+
 }

--- a/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/Button/DefaultEditBillingDetailsButtonStyle.swift
+++ b/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/Button/DefaultEditBillingDetailsButtonStyle.swift
@@ -16,7 +16,49 @@ public final class DefaultEditBillingDetailsButtonStyle: ElementButtonStyle {
     public var height: Double = Constants.Style.PaymentForm.InputBillingFormButton.height.rawValue
     public var width: Double = Constants.Style.PaymentForm.InputBillingFormButton.width.rawValue
     public var textLeading: CGFloat = Constants.Style.PaymentForm.InputBillingFormButton.textLeading.rawValue
-    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(normalColor: .clear,
-                                                                   focusColor: .clear,
-                                                                   errorColor: .clear)
+
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+    public var cornerRadius: CGFloat {
+        get { _cornerRadius }
+        set { _cornerRadius = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
+    public var borderWidth: CGFloat {
+        get { _borderWidth }
+        set { _borderWidth = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
+    public var normalBorderColor: UIColor {
+        get { _normalBorderColor }
+        set { _normalBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.focusColor")
+    public var focusBorderColor: UIColor {
+        get { _focusBorderColor }
+        set { _focusBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.errorColor")
+    public var errorBorderColor: UIColor {
+        get { _errorBorderColor }
+        set { _errorBorderColor = newValue }
+    }
+
+    internal var _cornerRadius: CGFloat = Constants.Style.BorderStyle.cornerRadius
+    internal var _borderWidth: CGFloat = Constants.Style.BorderStyle.borderWidth
+    internal var _normalBorderColor: UIColor = .clear
+    internal var _focusBorderColor: UIColor = .clear
+    internal var _errorBorderColor: UIColor = .clear
+
+    public lazy var borderStyle: ElementBorderStyle = {
+        DefaultBorderStyle(cornerRadius: _cornerRadius,
+                           borderWidth: _borderWidth,
+                           normalColor: _normalBorderColor,
+                           focusColor: _focusBorderColor,
+                           errorColor: _errorBorderColor)
+    }()
+
 }

--- a/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/View/DefaultBillingSummaryViewStyle.swift
+++ b/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/View/DefaultBillingSummaryViewStyle.swift
@@ -2,7 +2,6 @@ import UIKit
 
 public struct DefaultBillingSummaryViewStyle: BillingSummaryViewStyle {
     public var isMandatory = true
-    public var borderStyle: ElementBorderStyle = DefaultBorderStyle()
     public var separatorLineColor: UIColor = FramesUIStyle.Color.borderSecondary
     public var backgroundColor: UIColor = .clear
     public var button: ElementButtonStyle = DefaultEditBillingDetailsButtonStyle()
@@ -11,4 +10,34 @@ public struct DefaultBillingSummaryViewStyle: BillingSummaryViewStyle {
     public var summary: ElementStyle? = DefaultTitleLabelStyle()
     public var mandatory: ElementStyle?
     public var error: ElementErrorViewStyle?
+
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+    public var cornerRadius: CGFloat {
+        get { _cornerRadius }
+        set { _cornerRadius = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
+    public var borderWidth: CGFloat {
+        get { _borderWidth }
+        set { _borderWidth = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
+    public var borderColor: UIColor {
+        get { _borderColor }
+        set { _borderColor = newValue }
+    }
+
+    internal var _cornerRadius: CGFloat = Constants.Style.BorderStyle.cornerRadius
+    internal var _borderWidth: CGFloat = 0.5
+    internal var _borderColor: UIColor = FramesUIStyle.Color.borderPrimary
+
+    public lazy var borderStyle: ElementBorderStyle = {
+        DefaultBorderStyle(cornerRadius: _cornerRadius,
+                           borderWidth: _borderWidth,
+                           normalColor: _borderColor,
+                           focusColor: .clear,
+                           errorColor: .clear)
+    }()
 }

--- a/Source/UI/PaymentForm/Default Implementation/DefaultPayButtonFormStyle.swift
+++ b/Source/UI/PaymentForm/Default Implementation/DefaultPayButtonFormStyle.swift
@@ -23,8 +23,48 @@ public struct DefaultPayButtonFormStyle: ElementButtonStyle {
   public var height: Double = 56
   public var width: Double = 0
   public var textLeading: CGFloat = 0
-  public var borderStyle: ElementBorderStyle = DefaultBorderStyle(borderWidth: 0,
-                                                                 normalColor: .clear,
-                                                                 focusColor: .clear,
-                                                                 errorColor: .clear)
+
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+    public var cornerRadius: CGFloat {
+        get { _cornerRadius }
+        set { _cornerRadius = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
+    public var borderWidth: CGFloat {
+        get { _borderWidth }
+        set { _borderWidth = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
+    public var normalBorderColor: UIColor {
+        get { _normalBorderColor }
+        set { _normalBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.focusColor")
+    public var focusBorderColor: UIColor {
+        get { _focusBorderColor }
+        set { _focusBorderColor = newValue }
+    }
+
+    @available(*, deprecated, renamed: "borderStyle.errorColor")
+    public var errorBorderColor: UIColor {
+        get { _errorBorderColor }
+        set { _errorBorderColor = newValue }
+    }
+
+    internal var _cornerRadius: CGFloat = Constants.Style.BorderStyle.cornerRadius
+    internal var _borderWidth: CGFloat = 0
+    internal var _normalBorderColor: UIColor = .clear
+    internal var _focusBorderColor: UIColor = .clear
+    internal var _errorBorderColor: UIColor = .clear
+
+    public lazy var borderStyle: ElementBorderStyle = {
+        DefaultBorderStyle(cornerRadius: _cornerRadius,
+                           borderWidth: _borderWidth,
+                           normalColor: _normalBorderColor,
+                           focusColor: _focusBorderColor,
+                           errorColor: _errorBorderColor)
+    }()
 }

--- a/Source/UI/PaymentForm/StyleProtocol/BillingSummaryViewStyle.swift
+++ b/Source/UI/PaymentForm/StyleProtocol/BillingSummaryViewStyle.swift
@@ -2,6 +2,34 @@ import UIKit
 
 public protocol BillingSummaryViewStyle: CellButtonStyle {
     var summary: ElementStyle? { get set }
-    var borderStyle: ElementBorderStyle { get set }
+    var borderStyle: ElementBorderStyle { get }
     var separatorLineColor: UIColor { get set }
+
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.cornerRadius instead")
+    var cornerRadius: CGFloat { get }
+
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.borderWidth instead")
+    var borderWidth: CGFloat { get }
+}
+
+public extension BillingSummaryViewStyle {
+
+    var cornerRadius: CGFloat {
+        Constants.Style.BorderStyle.cornerRadius
+    }
+
+    var borderWidth: CGFloat {
+        Constants.Style.BorderStyle.borderWidth
+    }
+
+    var borderStyle: ElementBorderStyle {
+        // Deprecated warning required to encourage migrating away from using these properties
+        DefaultBorderStyle(cornerRadius: cornerRadius,
+                           borderWidth: borderWidth,
+                           normalColor: FramesUIStyle.Color.borderPrimary,
+                           focusColor: FramesUIStyle.Color.borderActive,
+                           errorColor: FramesUIStyle.Color.borderError,
+                           edges: .all,
+                           corners: .allCorners)
+    }
 }

--- a/Source/UI/PaymentForm/StyleProtocol/BillingSummaryViewStyle.swift
+++ b/Source/UI/PaymentForm/StyleProtocol/BillingSummaryViewStyle.swift
@@ -10,6 +10,9 @@ public protocol BillingSummaryViewStyle: CellButtonStyle {
 
     @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.borderWidth instead")
     var borderWidth: CGFloat { get }
+    
+    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.normalColor instead")
+    var borderColor: UIColor { get }
 }
 
 public extension BillingSummaryViewStyle {
@@ -21,14 +24,18 @@ public extension BillingSummaryViewStyle {
     var borderWidth: CGFloat {
         Constants.Style.BorderStyle.borderWidth
     }
+    
+    var borderColor: UIColor {
+        FramesUIStyle.Color.borderPrimary
+    }
 
     var borderStyle: ElementBorderStyle {
         // Deprecated warning required to encourage migrating away from using these properties
         DefaultBorderStyle(cornerRadius: cornerRadius,
                            borderWidth: borderWidth,
-                           normalColor: FramesUIStyle.Color.borderPrimary,
-                           focusColor: FramesUIStyle.Color.borderActive,
-                           errorColor: FramesUIStyle.Color.borderError,
+                           normalColor: borderColor,
+                           focusColor: .clear,
+                           errorColor: .clear,
                            edges: .all,
                            corners: .allCorners)
     }

--- a/Source/UI/PaymentForm/StyleProtocol/BillingSummaryViewStyle.swift
+++ b/Source/UI/PaymentForm/StyleProtocol/BillingSummaryViewStyle.swift
@@ -5,13 +5,13 @@ public protocol BillingSummaryViewStyle: CellButtonStyle {
     var borderStyle: ElementBorderStyle { get }
     var separatorLineColor: UIColor { get set }
 
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.cornerRadius instead")
+    @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     var cornerRadius: CGFloat { get }
 
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.borderWidth instead")
+    @available(*, deprecated, renamed: "borderStyle.borderWidth")
     var borderWidth: CGFloat { get }
-    
-    @available(*, deprecated, message: "Property will be removed soon. Use borderStyle.normalColor instead")
+
+    @available(*, deprecated, renamed: "borderStyle.normalColor")
     var borderColor: UIColor { get }
 }
 
@@ -24,7 +24,7 @@ public extension BillingSummaryViewStyle {
     var borderWidth: CGFloat {
         Constants.Style.BorderStyle.borderWidth
     }
-    
+
     var borderColor: UIColor {
         FramesUIStyle.Color.borderPrimary
     }

--- a/Source/UI/PaymentForm/View/BillingFormSummaryView.swift
+++ b/Source/UI/PaymentForm/View/BillingFormSummaryView.swift
@@ -54,7 +54,7 @@ class BillingFormSummaryView: UIView {
 
         summaryContainerView.update(with: style.borderStyle)
         summaryContainerView.updateBorderColor(to: style.borderStyle.normalColor)
-        summaryContainerView.backgroundColor = .clear
+        summaryContainerView.backgroundColor = style.backgroundColor
         summarySeparatorLineView.backgroundColor = style.separatorLineColor
 
         titleLabel.update(with: style.title)
@@ -148,6 +148,7 @@ extension BillingFormSummaryView {
             summaryContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
             summaryContainerView.bottomAnchor.constraint(equalTo: buttonView.bottomAnchor)
         ])
+        sendSubviewToBack(summaryContainerView)
         bringSubviewToFront(buttonView)
     }
 

--- a/Source/UI/PaymentForm/ViewController/PaymentViewController.swift
+++ b/Source/UI/PaymentForm/ViewController/PaymentViewController.swift
@@ -337,7 +337,6 @@ extension PaymentViewController {
     ]
     if let cardholderStyle = viewModel.paymentFormStyle?.cardholderInput {
       paymentViews.append(cardholderView)
-      cardholderView.update(style: cardholderStyle)
     }
     paymentViews.append(contentsOf: [cardNumberView, expiryDateView])
 

--- a/Source/UI/Theme/Generic/Theme+Border.swift
+++ b/Source/UI/Theme/Generic/Theme+Border.swift
@@ -1,0 +1,22 @@
+//
+//  Theme+Border.swift
+//  
+//
+//  Created by Alex Ioja-Yang on 15/06/2023.
+//
+
+import UIKit
+
+public extension Theme {
+
+    struct ThemeBorderStyle: ElementBorderStyle {
+        public var cornerRadius: CGFloat
+        public var borderWidth: CGFloat
+        public var normalColor: UIColor
+        public var focusColor: UIColor
+        public var errorColor: UIColor
+        public var edges: UIRectEdge?
+        public var corners: UIRectCorner?
+    }
+
+}

--- a/Source/UI/Theme/Generic/Theme+Button.swift
+++ b/Source/UI/Theme/Generic/Theme+Button.swift
@@ -27,6 +27,71 @@ public extension Theme {
         public var font: UIFont
         public var backgroundColor: UIColor = .clear
         public var textColor: UIColor
+
+        @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+        public var cornerRadius: CGFloat {
+            get { borderStyle.cornerRadius }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: newValue,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.borderWidth")
+        public var borderWidth: CGFloat {
+            get { borderStyle.borderWidth }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: newValue,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.normalColor")
+        public var normalBorderColor: UIColor {
+            get { borderStyle.normalColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: newValue,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.focusColor")
+        public var focusBorderColor: UIColor {
+            get { borderStyle.focusColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: newValue,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.errorColor")
+        public var errorBorderColor: UIColor {
+            get { borderStyle.errorColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: newValue)
+            }
+        }
     }
 
     /// Theme generated Button Style for showing Country Selection to user
@@ -47,6 +112,71 @@ public extension Theme {
         public var font: UIFont
         public var backgroundColor: UIColor
         public var textColor: UIColor
+
+        @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+        public var cornerRadius: CGFloat {
+            get { borderStyle.cornerRadius }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: newValue,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.borderWidth")
+        public var borderWidth: CGFloat {
+            get { borderStyle.borderWidth }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: newValue,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.normalColor")
+        public var normalBorderColor: UIColor {
+            get { borderStyle.normalColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: newValue,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.focusColor")
+        public var focusBorderColor: UIColor {
+            get { borderStyle.focusColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: newValue,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.errorColor")
+        public var errorBorderColor: UIColor {
+            get { borderStyle.errorColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: newValue)
+            }
+        }
     }
 
     /// Create a navigation button style with the provided title
@@ -70,22 +200,23 @@ public extension Theme {
     /// Create a button for launching a Country selection journey
     func buildCountryListButton(text: String,
                                 image: UIImage? = nil) -> CountryListButton {
-        CountryListButton(borderStyle: ThemeBorderStyle(cornerRadius: self.textInputBorderRadius,
-                                                        borderWidth: self.textInputBorderWidth,
-                                                        normalColor: self.textInputBorderColor,
-                                                        focusColor: self.focussedTextInputBorderColor,
-                                                        errorColor: self.errorBorderColor,
-                                                        edges: .all,
-                                                        corners: nil),
-                          disabledTextColor: self.secondaryFontColor,
-                          disabledTintColor: self.secondaryFontColor,
-                          activeTintColor: self.primaryFontColor,
-                          imageTintColor: self.primaryFontColor,
-                          image: image,
-                          text: text,
-                          font: inputFont,
-                          backgroundColor: self.textInputBackgroundColor,
-                          textColor: self.primaryFontColor)
+        CountryListButton(
+            borderStyle: ThemeBorderStyle(cornerRadius: self.textInputBorderRadius,
+                                          borderWidth: self.borderWidth,
+                                          normalColor: self.textInputBorderColor,
+                                          focusColor: self.focussedTextInputBorderColor,
+                                          errorColor: self.errorBorderColor,
+                                          edges: .all,
+                                          corners: nil),
+            disabledTextColor: self.secondaryFontColor,
+            disabledTintColor: self.secondaryFontColor,
+            activeTintColor: self.primaryFontColor,
+            imageTintColor: self.primaryFontColor,
+            image: image,
+            text: text,
+            font: inputFont,
+            backgroundColor: self.textInputBackgroundColor,
+            textColor: self.primaryFontColor)
     }
 
 }

--- a/Source/UI/Theme/Generic/Theme+TextField.swift
+++ b/Source/UI/Theme/Generic/Theme+TextField.swift
@@ -12,6 +12,7 @@ public extension Theme {
 
     /// Theme generated TextField style
     struct ThemeTextField: ElementTextFieldStyle {
+        public var borderStyle: ElementBorderStyle
         public var text: String
         public var isSupportingNumericKeyboard = true
         public var textAlignment: NSTextAlignment = .natural
@@ -22,38 +23,92 @@ public extension Theme {
         public var font: UIFont
         public var backgroundColor: UIColor
         public var textColor: UIColor
-        public var borderStyle: ElementBorderStyle
-    }
 
-    struct ThemeBorderStyle: ElementBorderStyle {
-        public var cornerRadius: CGFloat
-        public var borderWidth: CGFloat
-        public var normalColor: UIColor
-        public var focusColor: UIColor
-        public var errorColor: UIColor
-        public var edges: UIRectEdge?
-        public var corners: UIRectCorner?
+        @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+        public var cornerRadius: CGFloat {
+            get { borderStyle.cornerRadius }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: newValue,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.borderWidth")
+        public var borderWidth: CGFloat {
+            get { borderStyle.borderWidth }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: newValue,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.normalColor")
+        public var normalBorderColor: UIColor {
+            get { borderStyle.normalColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: newValue,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.focusColor")
+        public var focusBorderColor: UIColor {
+            get { borderStyle.focusColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: newValue,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.errorColor")
+        public var errorBorderColor: UIColor {
+            get { borderStyle.errorColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: newValue)
+            }
+        }
     }
 
     /// Create a TextField Style from text
     func buildTextField(text: String,
                         placeholderText: String,
                         isNumericInput: Bool) -> ThemeTextField {
-        ThemeTextField(text: text,
-                       isSupportingNumericKeyboard: isNumericInput,
-                       placeholder: placeholderText,
-                       tintColor: self.primaryFontColor,
-                       font: inputFont,
-                       backgroundColor: self.textInputBackgroundColor,
-                       textColor: self.primaryFontColor,
-                       borderStyle: ThemeBorderStyle(cornerRadius: self.textInputBorderRadius,
-                                                     borderWidth: self.textInputBorderWidth,
-                                                     normalColor: self.textInputBorderColor,
-                                                     focusColor: self.focussedTextInputBorderColor,
-                                                     errorColor: self.errorBorderColor,
-                                                     edges: .all,
-                                                     corners: nil)
-        )
+        ThemeTextField(
+            borderStyle: ThemeBorderStyle(cornerRadius: self.textInputBorderRadius,
+                                          borderWidth: self.textInputBorderWidth,
+                                          normalColor: self.textInputBorderColor,
+                                          focusColor: self.focussedTextInputBorderColor,
+                                          errorColor: self.errorBorderColor,
+                                          edges: .all,
+                                          corners: nil),
+            text: text,
+            isSupportingNumericKeyboard: isNumericInput,
+            placeholder: placeholderText,
+            tintColor: self.primaryFontColor,
+            font: inputFont,
+            backgroundColor: self.textInputBackgroundColor,
+            textColor: self.primaryFontColor)
     }
 
 }

--- a/Source/UI/Theme/PaymentForm/Theme+AddBillingSectionButton.swift
+++ b/Source/UI/Theme/PaymentForm/Theme+AddBillingSectionButton.swift
@@ -39,6 +39,71 @@ public extension Theme {
         public var font: UIFont
         public var backgroundColor: UIColor = .clear
         public var textColor: UIColor
+
+        @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+        public var cornerRadius: CGFloat {
+            get { borderStyle.cornerRadius }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: newValue,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.borderWidth")
+        public var borderWidth: CGFloat {
+            get { borderStyle.borderWidth }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: newValue,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.normalColor")
+        public var normalBorderColor: UIColor {
+            get { borderStyle.normalColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: newValue,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.focusColor")
+        public var focusBorderColor: UIColor {
+            get { borderStyle.focusColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: newValue,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.errorColor")
+        public var errorBorderColor: UIColor {
+            get { borderStyle.errorColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: newValue)
+            }
+        }
     }
 
     /// Create an Add Billing Section Button from Styles from core information
@@ -83,19 +148,20 @@ public extension Theme {
 
     /// Create an Add Billing Button from using theme and text
     func buildBillingButton(text: String) -> ThemeBillingButton {
-        ThemeBillingButton(borderStyle: ThemeBorderStyle(cornerRadius: self.textInputBorderRadius,
-                                                         borderWidth: self.textInputBorderWidth,
-                                                         normalColor: self.textInputBorderColor,
-                                                         focusColor: self.focussedTextInputBorderColor,
-                                                         errorColor: self.errorBorderColor,
-                                                         edges: .all,
-                                                         corners: nil),
-                           disabledTextColor: self.secondaryFontColor,
-                           disabledTintColor: self.secondaryFontColor,
-                           activeTintColor: self.primaryFontColor,
-                           text: text,
-                           font: buttonFont,
-                           textColor: self.buttonFontColor)
+        ThemeBillingButton(
+            borderStyle: ThemeBorderStyle(cornerRadius: self.textInputBorderRadius,
+                                          borderWidth: self.textInputBorderWidth,
+                                          normalColor: self.textInputBorderColor,
+                                          focusColor: self.focussedTextInputBorderColor,
+                                          errorColor: self.errorBorderColor,
+                                          edges: .all,
+                                          corners: nil),
+            disabledTextColor: self.secondaryFontColor,
+            disabledTintColor: self.secondaryFontColor,
+            activeTintColor: self.primaryFontColor,
+            text: text,
+            font: buttonFont,
+            textColor: self.buttonFontColor)
     }
 
 }

--- a/Source/UI/Theme/PaymentForm/Theme+BillingSummary.swift
+++ b/Source/UI/Theme/PaymentForm/Theme+BillingSummary.swift
@@ -22,6 +22,45 @@ public extension Theme {
         public var mandatory: ElementStyle?
         public var hint: ElementStyle?
         public var error: ElementErrorViewStyle?
+
+        @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+        public var cornerRadius: CGFloat {
+            get { borderStyle.cornerRadius }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: newValue,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.borderWidth")
+        public var borderWidth: CGFloat {
+            get { borderStyle.borderWidth }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: newValue,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.normalColor")
+        public var borderColor: UIColor {
+            get { borderStyle.normalColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: newValue,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
     }
 
     /// Theme generated Summary Content Style
@@ -54,21 +93,21 @@ public extension Theme {
                              error: ThemeError) -> ThemeBillingSummary {
         let summary = ThemeSummaryElement(font: inputFont,
                                           textColor: self.secondaryFontColor)
-
-        return ThemeBillingSummary(borderStyle: ThemeBorderStyle(cornerRadius: self.textInputBorderRadius,
-                                                                 borderWidth: self.textInputBorderWidth,
-                                                                 normalColor: self.textInputBorderColor,
-                                                                 focusColor: self.focussedTextInputBorderColor,
-                                                                 errorColor: self.errorBorderColor,
-                                                                 edges: .all,
-                                                                 corners: nil),
-                                   summary: summary,
-                                   separatorLineColor: self.secondaryFontColor,
-                                   button: button,
-                                   title: title,
-                                   mandatory: mandatory,
-                                   hint: subtitle,
-                                   error: error)
+        return ThemeBillingSummary(
+            borderStyle: ThemeBorderStyle(cornerRadius: textInputBorderRadius,
+                                          borderWidth: textInputBorderWidth,
+                                          normalColor: textInputBorderColor,
+                                          focusColor: focussedTextInputBorderColor,
+                                          errorColor: errorBorderColor,
+                                          edges: .all,
+                                          corners: nil),
+            summary: summary,
+            separatorLineColor: self.secondaryFontColor,
+            button: button,
+            title: title,
+            mandatory: mandatory,
+            hint: subtitle,
+            error: error)
     }
 
     /// Create a Billing Summary from provided content

--- a/Source/UI/Theme/PaymentForm/Theme+PayButton.swift
+++ b/Source/UI/Theme/PaymentForm/Theme+PayButton.swift
@@ -27,26 +27,92 @@ public extension Theme {
         public var font: UIFont
         public var backgroundColor: UIColor
         public var textColor: UIColor
+
+        @available(*, deprecated, renamed: "borderStyle.cornerRadius")
+        public var cornerRadius: CGFloat {
+            get { borderStyle.cornerRadius }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: newValue,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.borderWidth")
+        public var borderWidth: CGFloat {
+            get { borderStyle.borderWidth }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: newValue,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.normalColor")
+        public var normalBorderColor: UIColor {
+            get { borderStyle.normalColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: newValue,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.focusColor")
+        public var focusBorderColor: UIColor {
+            get { borderStyle.focusColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: newValue,
+                                               errorColor: themeBorderStyle.errorColor)
+            }
+        }
+
+        @available(*, deprecated, renamed: "borderStyle.errorColor")
+        public var errorBorderColor: UIColor {
+            get { borderStyle.errorColor }
+            set {
+                guard let themeBorderStyle = borderStyle as? ThemeBorderStyle else { return }
+                borderStyle = ThemeBorderStyle(cornerRadius: themeBorderStyle.cornerRadius,
+                                               borderWidth: themeBorderStyle.borderWidth,
+                                               normalColor: themeBorderStyle.normalColor,
+                                               focusColor: themeBorderStyle.focusColor,
+                                               errorColor: newValue)
+            }
+        }
     }
 
     /// Create a button for ending the Payment journey and attempting to tokenise inputs
     func buildPayButton(text: String,
                         image: UIImage? = nil) -> ThemePayButton {
-        ThemePayButton(borderStyle: ThemeBorderStyle(cornerRadius: self.textInputBorderRadius,
-                                                     borderWidth: self.textInputBorderWidth,
-                                                     normalColor: self.textInputBorderColor,
-                                                     focusColor: self.focussedTextInputBorderColor,
-                                                     errorColor: self.errorBorderColor,
-                                                     edges: .all,
-                                                     corners: nil),
-                       disabledTextColor: self.secondaryFontColor,
-                       disabledTintColor: .clear,
-                       activeTintColor: self.primaryFontColor,
-                       imageTintColor: self.primaryFontColor,
-                       image: image,
-                       text: text,
-                       font: buttonFont,
-                       backgroundColor: self.textInputBackgroundColor,
-                       textColor: self.primaryFontColor)
+        ThemePayButton(
+            borderStyle: ThemeBorderStyle(cornerRadius: self.textInputBorderRadius,
+                                          borderWidth: self.textInputBorderWidth,
+                                          normalColor: self.textInputBorderColor,
+                                          focusColor: self.focussedTextInputBorderColor,
+                                          errorColor: self.errorBorderColor,
+                                          edges: .all,
+                                          corners: nil),
+            disabledTextColor: self.secondaryFontColor,
+            disabledTintColor: .clear,
+            activeTintColor: self.primaryFontColor,
+            imageTintColor: self.primaryFontColor,
+            image: image,
+            text: text,
+            font: buttonFont,
+            backgroundColor: self.textInputBackgroundColor,
+            textColor: self.primaryFontColor)
     }
 }

--- a/Source/UI/Theme/Theme.swift
+++ b/Source/UI/Theme/Theme.swift
@@ -56,6 +56,14 @@ public struct Theme {
     public var textInputBorderRadius: CGFloat = 0
     /// Border width around text input fields
     public var textInputBorderWidth: CGFloat = 0
+    /// Border radius around data input sections when showing an error
+    public var errorBorderRadius: CGFloat = 4
+    /// Border width around data input sections when showing an error
+    public var errorBorderWidth: CGFloat = 1
+    /// Border radius around text input fields when showing an error
+    public var errorTextInputBorderRadius: CGFloat = 0
+    /// Border width around text input fields when showing an error
+    public var errorTextInputBorderWidth: CGFloat = 0
 
     public init(primaryFontColor: UIColor,
                 secondaryFontColor: UIColor,

--- a/Tests/UI/CommonUI/BorderViewTest.swift
+++ b/Tests/UI/CommonUI/BorderViewTest.swift
@@ -5,20 +5,20 @@ final class BorderViewTest: XCTestCase {
 
     func testInitDoesAddBorderLayer() {
         let borderView = BorderView()
-        XCTAssertEqual(borderView.layer.sublayers?.count, 1)
+        XCTAssertEqual(borderView.layer.sublayers?.count, 2)
     }
 
     func testLayoutSubviewsDoesNotAddAnotherLayer() {
         let borderView = BorderView()
         borderView.layoutSubviews()
-        XCTAssertEqual(borderView.layer.sublayers?.count, 1)
+        XCTAssertEqual(borderView.layer.sublayers?.count, 2)
     }
 
     func testUpdateStyleDoesNotAddLayer() {
         let borderView = BorderView()
         let style = DefaultBorderStyle()
         borderView.update(with: style)
-        XCTAssertEqual(borderView.layer.sublayers?.count, 1)
+        XCTAssertEqual(borderView.layer.sublayers?.count, 2)
     }
 
     func testInitDoesNotAddPath() throws {
@@ -34,11 +34,14 @@ final class BorderViewTest: XCTestCase {
         XCTAssertNil(shapeLayer.path)
     }
 
-    func testLayerFrameEqualToBoundsWhenLayoutSubviews() throws {
+    func testLayersEqualToBoundsWhenLayoutSubviews() throws {
         let borderView = BorderView(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
         borderView.layoutSubviews()
-        let shapeLayer = try XCTUnwrap(borderView.layer.sublayers?.first as? CAShapeLayer)
-        XCTAssertEqual(shapeLayer.frame, borderView.bounds)
+        
+        XCTAssertEqual(borderView.layer.sublayers?.isEmpty, false)
+        borderView.layer.sublayers?.forEach { (layer: CALayer) in
+            XCTAssertEqual((layer as? CAShapeLayer)?.frame, borderView.bounds)
+        }
     }
 
     func testUpdateStyleDoesAddPath() throws {
@@ -46,15 +49,26 @@ final class BorderViewTest: XCTestCase {
         let style = DefaultBorderStyle()
         borderView.update(with: style)
         borderView.layoutSubviews()
-        let shapeLayer = try XCTUnwrap(borderView.layer.sublayers?.first as? CAShapeLayer)
-        XCTAssertNotNil(shapeLayer.path)
+        
+        XCTAssertEqual(borderView.layer.sublayers?.isEmpty, false)
+        borderView.layer.sublayers?.forEach { (layer: CALayer) in
+            XCTAssertNotNil((layer as? CAShapeLayer)?.path)
+        }
     }
 
     func testBorderColorUpdate() throws {
         let borderView = BorderView()
         let expectedColor = UIColor.black
         borderView.updateBorderColor(to: expectedColor)
-        let shapeLayer = try XCTUnwrap(borderView.layer.sublayers?.first as? CAShapeLayer)
+        let shapeLayer = try XCTUnwrap(borderView.layer.sublayers?.last as? CAShapeLayer)
         XCTAssertEqual(shapeLayer.strokeColor, expectedColor.cgColor)
+    }
+    
+    func testBackgroundColorUpdate() throws {
+        let borderView = BorderView()
+        let expectedColor = UIColor.black
+        borderView.backgroundColor = expectedColor
+        let shapeLayer = try XCTUnwrap(borderView.layer.sublayers?.first as? CAShapeLayer)
+        XCTAssertEqual(shapeLayer.fillColor, expectedColor.cgColor)
     }
 }

--- a/iOS Example Frame/iOS Example Frame/Factory/Factory+UITest.swift
+++ b/iOS Example Frame/iOS Example Frame/Factory/Factory+UITest.swift
@@ -105,7 +105,9 @@ extension ThemeDemo {
         var payButton = theme.buildPayButton(text: "Pay now")
         payButton.textAlignment = .center
 
-        let billingSummary = theme.buildBillingSummary(buttonText: "Change billing details", titleText: "Billing details")
+        var billingSummary = theme.buildBillingSummary(buttonText: "Change billing details", titleText: "Billing details")
+        billingSummary.borderColor = .white
+        billingSummary.borderWidth = 1
 
         let paymentFormStyle = theme.buildPaymentForm(
             headerView: theme.buildPaymentHeader(title: "Payment details",

--- a/iOS Example Frame/iOS Example Frame/ThemeDemo.swift
+++ b/iOS Example Frame/iOS Example Frame/ThemeDemo.swift
@@ -25,6 +25,8 @@ enum ThemeDemo {
 
         var billingSummary = theme.buildBillingSummary(buttonText: "Change billing details",
                                                        titleText: "Billing details")
+        billingSummary.borderStyle.normalColor = .white
+        billingSummary.borderStyle.borderWidth = 1
 
         var cardholderInput = theme.buildPaymentInput(isTextFieldNumericInput: false,
                                                       titleText: "Cardholder name",


### PR DESCRIPTION
[Jira task](https://checkout.atlassian.net/browse/PIMOB-2011)

Middle layer between 4.0.x versions and future 4.1.0 to avoid existing users facing syntax breaking changes on update.


***


Side effects of the changes in current form:

Our SDK will trigger 13 warnings that originate from the SDK to the application consuming SDK. In the current approach of using interfaces for the styling objects we are unable to transition without triggering those warnings.
In our Default objects we are able to avoid by introducing an internal state that aligns the new destination and the deprecated location. Protocols cannot however contain state so do not allow this.

<img width="330" alt="Screenshot 2023-06-15 at 11 15 23" src="https://github.com/checkout/frames-ios/assets/102028170/44b298e9-3563-4973-9321-d50006dd36df">
