### PR TITLE
PIMOB-2012: Add background layer to borders

### DIFF
--- a/Source/Extensions/CAShapeLayerExtension.swift
+++ b/Source/Extensions/CAShapeLayerExtension.swift
@@ -25,6 +25,13 @@ extension CAShapeLayer {
         self.path = path.cgPath
     }
 
+    func createBackground(with style: ElementBorderStyle) {
+        let path = UIBezierPath(roundedRect: frame,
+                                byRoundingCorners: style.corners ?? [],
+                                cornerRadii: CGSize(width: style.cornerRadius, height: style.cornerRadius))
+        self.path = path.cgPath
+    }
+
     /*
      (0,0)  c-----------c  (100,0)
             |           |

--- a/Source/UI/BillingForm/View/BillingFormTextFieldView.swift
+++ b/Source/UI/BillingForm/View/BillingFormTextFieldView.swift
@@ -123,7 +123,7 @@ class BillingFormTextFieldView: UIView {
         style.textfield.borderStyle.normalColor
         textFieldContainerBorder.update(with: style.textfield.borderStyle)
         textFieldContainerBorder.updateBorderColor(to: borderColor)
-        textFieldContainer.backgroundColor = style.textfield.backgroundColor
+        textFieldContainerBorder.backgroundColor = style.textfield.backgroundColor
     }
 
     private func update(textField: BillingFormTextField?, style: CellTextFieldStyle, textFieldValue: String?, tag: Int) {

--- a/Source/UI/CommonUI/View/Component/BorderView.swift
+++ b/Source/UI/CommonUI/View/Component/BorderView.swift
@@ -6,9 +6,18 @@ final class BorderView: UIView {
 
     /// shaper layer that draw edges and corners
     private var borderLayer = CAShapeLayer()
+    private var backgroundLayer = CAShapeLayer()
+
+    override var backgroundColor: UIColor? {
+        get { UIColor(cgColor: backgroundLayer.backgroundColor ?? UIColor.clear.cgColor) }
+        set {
+            backgroundLayer.fillColor = newValue?.cgColor
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        layer.addSublayer(backgroundLayer)
         layer.addSublayer(borderLayer)
         backgroundColor = .clear
     }
@@ -16,8 +25,10 @@ final class BorderView: UIView {
     // Keep border layer size in sync with owning view
     override func layoutSubviews() {
         super.layoutSubviews()
+        backgroundLayer.frame = bounds
         borderLayer.frame = bounds
         guard let style = style else { return }
+        backgroundLayer.createBackground(with: style)
         borderLayer.createCustomBorder(with: style)
     }
 

--- a/Source/UI/CommonUI/View/Component/InputView.swift
+++ b/Source/UI/CommonUI/View/Component/InputView.swift
@@ -114,6 +114,7 @@ class InputView: UIView {
         textFieldContainerBorder.update(with: style.textfield.borderStyle)
         textFieldContainerBorder.updateBorderColor(to: borderColor)
         textFieldContainerBorder.backgroundColor = style.textfield.backgroundColor
+        textFieldContainerBorder.setNeedsLayout()
     }
 
     private func updateTextFieldContainer(image: UIImage?, animated: Bool) {

--- a/Source/UI/CommonUI/View/Core/ButtonView.swift
+++ b/Source/UI/CommonUI/View/Core/ButtonView.swift
@@ -61,7 +61,6 @@ class ButtonView: UIView {
 
     func update(with style: ElementButtonStyle) {
         self.style = style
-        backgroundColor = style.backgroundColor
         clipsToBounds = true
         borderView.update(with: style.borderStyle)
         borderView.updateBorderColor(to: style.borderStyle.normalColor)
@@ -74,7 +73,7 @@ class ButtonView: UIView {
     }
 
     private func updateButtonStyle(with style: ElementButtonStyle) {
-        backgroundColor = isEnabled ? style.backgroundColor : style.disabledTintColor
+        borderView.backgroundColor = isEnabled ? style.backgroundColor : style.disabledTintColor
         button.tintColor = .clear
         button.heightAnchor.constraint(equalToConstant: style.height).isActive = true
         button.accessibilityIdentifier = style.text

--- a/Source/UI/PaymentForm/View/BillingFormSummaryView.swift
+++ b/Source/UI/PaymentForm/View/BillingFormSummaryView.swift
@@ -54,7 +54,7 @@ class BillingFormSummaryView: UIView {
 
         summaryContainerView.update(with: style.borderStyle)
         summaryContainerView.updateBorderColor(to: style.borderStyle.normalColor)
-        summaryContainerView.backgroundColor = .clear
+        summaryContainerView.backgroundColor = style.backgroundColor
         summarySeparatorLineView.backgroundColor = style.separatorLineColor
 
         titleLabel.update(with: style.title)
@@ -148,6 +148,7 @@ extension BillingFormSummaryView {
             summaryContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
             summaryContainerView.bottomAnchor.constraint(equalTo: buttonView.bottomAnchor)
         ])
+        sendSubviewToBack(summaryContainerView)
         bringSubviewToFront(buttonView)
     }
 

--- a/Source/UI/PaymentForm/ViewController/PaymentViewController.swift
+++ b/Source/UI/PaymentForm/ViewController/PaymentViewController.swift
@@ -337,7 +337,6 @@ extension PaymentViewController {
     ]
     if let cardholderStyle = viewModel.paymentFormStyle?.cardholderInput {
       paymentViews.append(cardholderView)
-      cardholderView.update(style: cardholderStyle)
     }
     paymentViews.append(contentsOf: [cardNumberView, expiryDateView])
 

--- a/Tests/UI/CommonUI/BorderViewTest.swift
+++ b/Tests/UI/CommonUI/BorderViewTest.swift
@@ -5,20 +5,20 @@ final class BorderViewTest: XCTestCase {
 
     func testInitDoesAddBorderLayer() {
         let borderView = BorderView()
-        XCTAssertEqual(borderView.layer.sublayers?.count, 1)
+        XCTAssertEqual(borderView.layer.sublayers?.count, 2)
     }
 
     func testLayoutSubviewsDoesNotAddAnotherLayer() {
         let borderView = BorderView()
         borderView.layoutSubviews()
-        XCTAssertEqual(borderView.layer.sublayers?.count, 1)
+        XCTAssertEqual(borderView.layer.sublayers?.count, 2)
     }
 
     func testUpdateStyleDoesNotAddLayer() {
         let borderView = BorderView()
         let style = DefaultBorderStyle()
         borderView.update(with: style)
-        XCTAssertEqual(borderView.layer.sublayers?.count, 1)
+        XCTAssertEqual(borderView.layer.sublayers?.count, 2)
     }
 
     func testInitDoesNotAddPath() throws {
@@ -34,11 +34,14 @@ final class BorderViewTest: XCTestCase {
         XCTAssertNil(shapeLayer.path)
     }
 
-    func testLayerFrameEqualToBoundsWhenLayoutSubviews() throws {
+    func testLayersEqualToBoundsWhenLayoutSubviews() throws {
         let borderView = BorderView(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
         borderView.layoutSubviews()
-        let shapeLayer = try XCTUnwrap(borderView.layer.sublayers?.first as? CAShapeLayer)
-        XCTAssertEqual(shapeLayer.frame, borderView.bounds)
+        
+        XCTAssertEqual(borderView.layer.sublayers?.isEmpty, false)
+        borderView.layer.sublayers?.forEach { (layer: CALayer) in
+            XCTAssertEqual((layer as? CAShapeLayer)?.frame, borderView.bounds)
+        }
     }
 
     func testUpdateStyleDoesAddPath() throws {
@@ -46,15 +49,26 @@ final class BorderViewTest: XCTestCase {
         let style = DefaultBorderStyle()
         borderView.update(with: style)
         borderView.layoutSubviews()
-        let shapeLayer = try XCTUnwrap(borderView.layer.sublayers?.first as? CAShapeLayer)
-        XCTAssertNotNil(shapeLayer.path)
+        
+        XCTAssertEqual(borderView.layer.sublayers?.isEmpty, false)
+        borderView.layer.sublayers?.forEach { (layer: CALayer) in
+            XCTAssertNotNil((layer as? CAShapeLayer)?.path)
+        }
     }
 
     func testBorderColorUpdate() throws {
         let borderView = BorderView()
         let expectedColor = UIColor.black
         borderView.updateBorderColor(to: expectedColor)
-        let shapeLayer = try XCTUnwrap(borderView.layer.sublayers?.first as? CAShapeLayer)
+        let shapeLayer = try XCTUnwrap(borderView.layer.sublayers?.last as? CAShapeLayer)
         XCTAssertEqual(shapeLayer.strokeColor, expectedColor.cgColor)
+    }
+    
+    func testBackgroundColorUpdate() throws {
+        let borderView = BorderView()
+        let expectedColor = UIColor.black
+        borderView.backgroundColor = expectedColor
+        let shapeLayer = try XCTUnwrap(borderView.layer.sublayers?.first as? CAShapeLayer)
+        XCTAssertEqual(shapeLayer.fillColor, expectedColor.cgColor)
     }
 }


### PR DESCRIPTION
[Jira task](https://checkout.atlassian.net/browse/PIMOB-2012)

Due to the background colour currently being assigned directly to UIView, it does not account for the custom border behaviour we enable.
The current border layer does not have to be complete as we support custom behaviour, so the solution proposed is to create another layer with a complete path that copies the border. We then use this as a background layer and assign the colour to it.

***


**Possible outcome of this change:**

![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-20 at 09 36 54](https://github.com/checkout/frames-ios/assets/102028170/1870e558-5a5a-402b-8287-38a97fe86350)