### PR TITLE
PIMOB-XXXX

### DIFF
--- a/Source/UI/BillingForm/Default Implementation/BillingForm/Header/Cancel/DefaultCancelButtonFormStyle.swift
+++ b/Source/UI/BillingForm/Default Implementation/BillingForm/Header/Cancel/DefaultCancelButtonFormStyle.swift
@@ -19,45 +19,37 @@ public struct DefaultCancelButtonFormStyle: ElementButtonStyle {
 
     @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     public var cornerRadius: CGFloat {
-        get { _cornerRadius }
-        set { _cornerRadius = newValue }
+        get { borderStyle.cornerRadius }
+        set { borderStyle.cornerRadius = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.borderWidth")
     public var borderWidth: CGFloat {
-        get { _borderWidth }
-        set { _borderWidth = newValue }
+        get { borderStyle.borderWidth }
+        set { borderStyle.borderWidth = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.normalColor")
     public var normalBorderColor: UIColor {
-        get { _normalBorderColor }
-        set { _normalBorderColor = newValue }
+        get { borderStyle.normalColor }
+        set { borderStyle.normalColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.focusColor")
     public var focusBorderColor: UIColor {
-        get { _focusBorderColor }
-        set { _focusBorderColor = newValue }
+        get { borderStyle.focusColor }
+        set { borderStyle.focusColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.errorColor")
     public var errorBorderColor: UIColor {
-        get { _errorBorderColor }
-        set { _errorBorderColor = newValue }
+        get { borderStyle.errorColor }
+        set { borderStyle.errorColor = newValue }
     }
 
-    internal var _cornerRadius: CGFloat = 0
-    internal var _borderWidth: CGFloat = 0
-    internal var _normalBorderColor: UIColor = .clear
-    internal var _focusBorderColor: UIColor = .clear
-    internal var _errorBorderColor: UIColor = .clear
-
-    public lazy var borderStyle: ElementBorderStyle = {
-        DefaultBorderStyle(cornerRadius: _cornerRadius,
-                           borderWidth: _borderWidth,
-                           normalColor: _normalBorderColor,
-                           focusColor: _focusBorderColor,
-                           errorColor: _errorBorderColor)
-    }()
+    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(cornerRadius: 0,
+                                                                    borderWidth: 0,
+                                                                    normalColor: .clear,
+                                                                    focusColor: .clear,
+                                                                    errorColor: .clear)
 }

--- a/Source/UI/BillingForm/Default Implementation/BillingForm/Header/Done/DefaultDoneFormButtonStyle.swift
+++ b/Source/UI/BillingForm/Default Implementation/BillingForm/Header/Done/DefaultDoneFormButtonStyle.swift
@@ -19,46 +19,37 @@ public struct DefaultDoneFormButtonStyle: ElementButtonStyle {
 
     @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     public var cornerRadius: CGFloat {
-        get { _cornerRadius }
-        set { _cornerRadius = newValue }
+        get { borderStyle.cornerRadius }
+        set { borderStyle.cornerRadius = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.borderWidth")
     public var borderWidth: CGFloat {
-        get { _borderWidth }
-        set { _borderWidth = newValue }
+        get { borderStyle.borderWidth }
+        set { borderStyle.borderWidth = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.normalColor")
     public var normalBorderColor: UIColor {
-        get { _normalBorderColor }
-        set { _normalBorderColor = newValue }
+        get { borderStyle.normalColor }
+        set { borderStyle.normalColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.focusColor")
     public var focusBorderColor: UIColor {
-        get { _focusBorderColor }
-        set { _focusBorderColor = newValue }
+        get { borderStyle.focusColor }
+        set { borderStyle.focusColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.errorColor")
     public var errorBorderColor: UIColor {
-        get { _errorBorderColor }
-        set { _errorBorderColor = newValue }
+        get { borderStyle.errorColor }
+        set { borderStyle.errorColor = newValue }
     }
 
-    internal var _cornerRadius: CGFloat = 0
-    internal var _borderWidth: CGFloat = 0
-    internal var _normalBorderColor: UIColor = .clear
-    internal var _focusBorderColor: UIColor = .clear
-    internal var _errorBorderColor: UIColor = .clear
-
-    public lazy var borderStyle: ElementBorderStyle = {
-        DefaultBorderStyle(cornerRadius: _cornerRadius,
-                           borderWidth: _borderWidth,
-                           normalColor: _normalBorderColor,
-                           focusColor: _focusBorderColor,
-                           errorColor: _errorBorderColor)
-    }()
-
+    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(cornerRadius: 0,
+                                                                    borderWidth: 0,
+                                                                    normalColor: .clear,
+                                                                    focusColor: .clear,
+                                                                    errorColor: .clear)
 }

--- a/Source/UI/BillingForm/Default Implementation/Elements/Country/DefaultCountryFormButtonStyle.swift
+++ b/Source/UI/BillingForm/Default Implementation/Elements/Country/DefaultCountryFormButtonStyle.swift
@@ -19,45 +19,37 @@ public struct DefaultCountryFormButtonStyle: ElementButtonStyle {
 
     @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     public var cornerRadius: CGFloat {
-        get { _cornerRadius }
-        set { _cornerRadius = newValue }
+        get { borderStyle.cornerRadius }
+        set { borderStyle.cornerRadius = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.borderWidth")
     public var borderWidth: CGFloat {
-        get { _borderWidth }
-        set { _borderWidth = newValue }
+        get { borderStyle.borderWidth }
+        set { borderStyle.borderWidth = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.normalColor")
     public var normalBorderColor: UIColor {
-        get { _normalBorderColor }
-        set { _normalBorderColor = newValue }
+        get { borderStyle.normalColor }
+        set { borderStyle.normalColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.focusColor")
     public var focusBorderColor: UIColor {
-        get { _focusBorderColor }
-        set { _focusBorderColor = newValue }
+        get { borderStyle.focusColor }
+        set { borderStyle.focusColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.errorColor")
     public var errorBorderColor: UIColor {
-        get { _errorBorderColor }
-        set { _errorBorderColor = newValue }
+        get { borderStyle.errorColor }
+        set { borderStyle.errorColor = newValue }
     }
 
-    internal var _cornerRadius: CGFloat = Constants.Style.BorderStyle.cornerRadius
-    internal var _borderWidth: CGFloat = Constants.Style.BorderStyle.borderWidth
-    internal var _normalBorderColor: UIColor = FramesUIStyle.Color.borderPrimary
-    internal var _focusBorderColor: UIColor = FramesUIStyle.Color.borderActive
-    internal var _errorBorderColor: UIColor = FramesUIStyle.Color.borderError
-
-    public lazy var borderStyle: ElementBorderStyle = {
-        DefaultBorderStyle(cornerRadius: _cornerRadius,
-                           borderWidth: _borderWidth,
-                           normalColor: _normalBorderColor,
-                           focusColor: _focusBorderColor,
-                           errorColor: _errorBorderColor)
-    }()
+    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(cornerRadius: Constants.Style.BorderStyle.cornerRadius,
+                                                                    borderWidth: Constants.Style.BorderStyle.borderWidth,
+                                                                    normalColor: FramesUIStyle.Color.borderPrimary,
+                                                                    focusColor: FramesUIStyle.Color.borderActive,
+                                                                    errorColor: FramesUIStyle.Color.borderError)
 }

--- a/Source/UI/BillingForm/Default Implementation/Elements/TextField/DefaultTextField.swift
+++ b/Source/UI/BillingForm/Default Implementation/Elements/TextField/DefaultTextField.swift
@@ -15,45 +15,37 @@ public struct DefaultTextField: ElementTextFieldStyle {
 
     @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     public var cornerRadius: CGFloat {
-        get { _cornerRadius }
-        set { _cornerRadius = newValue }
+        get { borderStyle.cornerRadius }
+        set { borderStyle.cornerRadius = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.borderWidth")
     public var borderWidth: CGFloat {
-        get { _borderWidth }
-        set { _borderWidth = newValue }
+        get { borderStyle.borderWidth }
+        set { borderStyle.borderWidth = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.normalColor")
     public var normalBorderColor: UIColor {
-        get { _normalBorderColor }
-        set { _normalBorderColor = newValue }
+        get { borderStyle.normalColor }
+        set { borderStyle.normalColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.focusColor")
     public var focusBorderColor: UIColor {
-        get { _focusBorderColor }
-        set { _focusBorderColor = newValue }
+        get { borderStyle.focusColor }
+        set { borderStyle.focusColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.errorColor")
     public var errorBorderColor: UIColor {
-        get { _errorBorderColor }
-        set { _errorBorderColor = newValue }
+        get { borderStyle.errorColor }
+        set { borderStyle.errorColor = newValue }
     }
 
-    internal var _cornerRadius: CGFloat = 10
-    internal var _borderWidth: CGFloat = 1
-    internal var _normalBorderColor: UIColor = FramesUIStyle.Color.borderPrimary
-    internal var _focusBorderColor: UIColor = FramesUIStyle.Color.borderActive
-    internal var _errorBorderColor: UIColor = FramesUIStyle.Color.borderError
-
-    public lazy var borderStyle: ElementBorderStyle = {
-        DefaultBorderStyle(cornerRadius: _cornerRadius,
-                           borderWidth: _borderWidth,
-                           normalColor: _normalBorderColor,
-                           focusColor: _focusBorderColor,
-                           errorColor: _errorBorderColor)
-    }()
+    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(cornerRadius: 10,
+                                                                    borderWidth: 1,
+                                                                    normalColor: FramesUIStyle.Color.borderPrimary,
+                                                                    focusColor: FramesUIStyle.Color.borderActive,
+                                                                    errorColor: FramesUIStyle.Color.borderError)
 }

--- a/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/Button/DefaultAddBillingDetailsButtonStyle.swift
+++ b/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/Button/DefaultAddBillingDetailsButtonStyle.swift
@@ -19,46 +19,37 @@ public final class DefaultAddBillingDetailsButtonStyle: ElementButtonStyle {
 
     @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     public var cornerRadius: CGFloat {
-        get { _cornerRadius }
-        set { _cornerRadius = newValue }
+        get { borderStyle.cornerRadius }
+        set { borderStyle.cornerRadius = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.borderWidth")
     public var borderWidth: CGFloat {
-        get { _borderWidth }
-        set { _borderWidth = newValue }
+        get { borderStyle.borderWidth }
+        set { borderStyle.borderWidth = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.normalColor")
     public var normalBorderColor: UIColor {
-        get { _normalBorderColor }
-        set { _normalBorderColor = newValue }
+        get { borderStyle.normalColor }
+        set { borderStyle.normalColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.focusColor")
     public var focusBorderColor: UIColor {
-        get { _focusBorderColor }
-        set { _focusBorderColor = newValue }
+        get { borderStyle.focusColor }
+        set { borderStyle.focusColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.errorColor")
     public var errorBorderColor: UIColor {
-        get { _errorBorderColor }
-        set { _errorBorderColor = newValue }
+        get { borderStyle.errorColor }
+        set { borderStyle.errorColor = newValue }
     }
 
-    internal var _cornerRadius: CGFloat = Constants.Style.BorderStyle.cornerRadius
-    internal var _borderWidth: CGFloat = Constants.Style.BorderStyle.borderWidth
-    internal var _normalBorderColor: UIColor = FramesUIStyle.Color.borderActive
-    internal var _focusBorderColor: UIColor = FramesUIStyle.Color.borderActive
-    internal var _errorBorderColor: UIColor = FramesUIStyle.Color.borderError
-
-    public lazy var borderStyle: ElementBorderStyle = {
-        DefaultBorderStyle(cornerRadius: _cornerRadius,
-                           borderWidth: _borderWidth,
-                           normalColor: _normalBorderColor,
-                           focusColor: _focusBorderColor,
-                           errorColor: _errorBorderColor)
-    }()
-
+    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(cornerRadius: Constants.Style.BorderStyle.cornerRadius,
+                                                                    borderWidth: Constants.Style.BorderStyle.borderWidth,
+                                                                    normalColor: FramesUIStyle.Color.borderPrimary,
+                                                                    focusColor: FramesUIStyle.Color.borderActive,
+                                                                    errorColor: FramesUIStyle.Color.borderError)
 }

--- a/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/Button/DefaultEditBillingDetailsButtonStyle.swift
+++ b/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/Button/DefaultEditBillingDetailsButtonStyle.swift
@@ -19,46 +19,37 @@ public final class DefaultEditBillingDetailsButtonStyle: ElementButtonStyle {
 
     @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     public var cornerRadius: CGFloat {
-        get { _cornerRadius }
-        set { _cornerRadius = newValue }
+        get { borderStyle.cornerRadius }
+        set { borderStyle.cornerRadius = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.borderWidth")
     public var borderWidth: CGFloat {
-        get { _borderWidth }
-        set { _borderWidth = newValue }
+        get { borderStyle.borderWidth }
+        set { borderStyle.borderWidth = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.normalColor")
     public var normalBorderColor: UIColor {
-        get { _normalBorderColor }
-        set { _normalBorderColor = newValue }
+        get { borderStyle.normalColor }
+        set { borderStyle.normalColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.focusColor")
     public var focusBorderColor: UIColor {
-        get { _focusBorderColor }
-        set { _focusBorderColor = newValue }
+        get { borderStyle.focusColor }
+        set { borderStyle.focusColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.errorColor")
     public var errorBorderColor: UIColor {
-        get { _errorBorderColor }
-        set { _errorBorderColor = newValue }
+        get { borderStyle.errorColor }
+        set { borderStyle.errorColor = newValue }
     }
 
-    internal var _cornerRadius: CGFloat = Constants.Style.BorderStyle.cornerRadius
-    internal var _borderWidth: CGFloat = Constants.Style.BorderStyle.borderWidth
-    internal var _normalBorderColor: UIColor = .clear
-    internal var _focusBorderColor: UIColor = .clear
-    internal var _errorBorderColor: UIColor = .clear
-
-    public lazy var borderStyle: ElementBorderStyle = {
-        DefaultBorderStyle(cornerRadius: _cornerRadius,
-                           borderWidth: _borderWidth,
-                           normalColor: _normalBorderColor,
-                           focusColor: _focusBorderColor,
-                           errorColor: _errorBorderColor)
-    }()
-
+    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(cornerRadius: Constants.Style.BorderStyle.cornerRadius,
+                                                                    borderWidth: Constants.Style.BorderStyle.borderWidth,
+                                                                    normalColor: .clear,
+                                                                    focusColor: .clear,
+                                                                    errorColor: .clear)
 }

--- a/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/View/DefaultBillingSummaryViewStyle.swift
+++ b/Source/UI/PaymentForm/Default Implementation/BillingFormSummary/Summary/View/DefaultBillingSummaryViewStyle.swift
@@ -13,31 +13,25 @@ public struct DefaultBillingSummaryViewStyle: BillingSummaryViewStyle {
 
     @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     public var cornerRadius: CGFloat {
-        get { _cornerRadius }
-        set { _cornerRadius = newValue }
+        get { borderStyle.cornerRadius }
+        set { borderStyle.cornerRadius = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.borderWidth")
     public var borderWidth: CGFloat {
-        get { _borderWidth }
-        set { _borderWidth = newValue }
+        get { borderStyle.borderWidth }
+        set { borderStyle.borderWidth = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.normalColor")
     public var borderColor: UIColor {
-        get { _borderColor }
-        set { _borderColor = newValue }
+        get { borderStyle.normalColor }
+        set { borderStyle.normalColor = newValue }
     }
 
-    internal var _cornerRadius: CGFloat = Constants.Style.BorderStyle.cornerRadius
-    internal var _borderWidth: CGFloat = 0.5
-    internal var _borderColor: UIColor = FramesUIStyle.Color.borderPrimary
-
-    public lazy var borderStyle: ElementBorderStyle = {
-        DefaultBorderStyle(cornerRadius: _cornerRadius,
-                           borderWidth: _borderWidth,
-                           normalColor: _borderColor,
-                           focusColor: .clear,
-                           errorColor: .clear)
-    }()
+    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(cornerRadius: Constants.Style.BorderStyle.cornerRadius,
+                                                                    borderWidth: 0.5,
+                                                                    normalColor: FramesUIStyle.Color.borderPrimary,
+                                                                    focusColor: .clear,
+                                                                    errorColor: .clear)
 }

--- a/Source/UI/PaymentForm/Default Implementation/DefaultPayButtonFormStyle.swift
+++ b/Source/UI/PaymentForm/Default Implementation/DefaultPayButtonFormStyle.swift
@@ -26,45 +26,37 @@ public struct DefaultPayButtonFormStyle: ElementButtonStyle {
 
     @available(*, deprecated, renamed: "borderStyle.cornerRadius")
     public var cornerRadius: CGFloat {
-        get { _cornerRadius }
-        set { _cornerRadius = newValue }
+        get { borderStyle.cornerRadius }
+        set { borderStyle.cornerRadius = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.borderWidth")
     public var borderWidth: CGFloat {
-        get { _borderWidth }
-        set { _borderWidth = newValue }
+        get { borderStyle.borderWidth }
+        set { borderStyle.borderWidth = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.normalColor")
     public var normalBorderColor: UIColor {
-        get { _normalBorderColor }
-        set { _normalBorderColor = newValue }
+        get { borderStyle.normalColor }
+        set { borderStyle.normalColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.focusColor")
     public var focusBorderColor: UIColor {
-        get { _focusBorderColor }
-        set { _focusBorderColor = newValue }
+        get { borderStyle.focusColor }
+        set { borderStyle.focusColor = newValue }
     }
 
     @available(*, deprecated, renamed: "borderStyle.errorColor")
     public var errorBorderColor: UIColor {
-        get { _errorBorderColor }
-        set { _errorBorderColor = newValue }
+        get { borderStyle.errorColor }
+        set { borderStyle.errorColor = newValue }
     }
 
-    internal var _cornerRadius: CGFloat = Constants.Style.BorderStyle.cornerRadius
-    internal var _borderWidth: CGFloat = 0
-    internal var _normalBorderColor: UIColor = .clear
-    internal var _focusBorderColor: UIColor = .clear
-    internal var _errorBorderColor: UIColor = .clear
-
-    public lazy var borderStyle: ElementBorderStyle = {
-        DefaultBorderStyle(cornerRadius: _cornerRadius,
-                           borderWidth: _borderWidth,
-                           normalColor: _normalBorderColor,
-                           focusColor: _focusBorderColor,
-                           errorColor: _errorBorderColor)
-    }()
+    public var borderStyle: ElementBorderStyle = DefaultBorderStyle(cornerRadius: Constants.Style.BorderStyle.cornerRadius,
+                                                                    borderWidth: 0,
+                                                                    normalColor: .clear,
+                                                                    focusColor: .clear,
+                                                                    errorColor: .clear)
 }


### PR DESCRIPTION
In [previous PR](https://github.com/checkout/frames-ios/pull/406) (Avoid breaking API for borders release) we have over-optimised by incorrectly assuming that Default objects would have a declared state from consumers. 
This is not a valid possibility as consumers cannot declare their own object conforming to `Default...` implementations, so the problem it was aiming to address it was not applicable to begin with.
Furthermore, using this format we were overriding any `borderStyle` implementation provided back to defaults, in effect making it impossible to use new APIs on `Default` customisation path.

***

Proposed changes are moving the default border style into a property assigned at object initialisation. This then allows deprecated & new code to correctly persist state and pass along objects that have been customised, no longer losing configuration.