### PR TITLE
Update ChangeLog and ReadMe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 
 #### 4.x Releases
 
+## [4.1.0](https://github.com/checkout/frames-ios/releases/tag/4.1.0)
+
+Released on 2023-06-27
+
+Updates:
+
+- Added a new feature to set custom border styles
+- Added validation to avoid the SDK being used with empty public keys
+
 ## [4.0.5](https://github.com/checkout/frames-ios/releases/tag/4.0.5)
 
 Released on 2023-05-24

--- a/README.md
+++ b/README.md
@@ -257,6 +257,19 @@ paymentFormStyle.backgroundColor = UIColor.darkGray
 // Change card number input placeholder value
 paymentFormStyle.expiryDate.textfield.placeholder = "00 / 00"
 
+// Add custom border style around the Payment Button
+if var payButton = paymentFormStyle.payButton as? DefaultPayButtonFormStyle {
+  let payButtonBorder = DefaultBorderStyle(
+      cornerRadius: 26,
+      borderWidth: 3,
+      normalColor: .black,
+      focusColor: .clear,
+      errorColor: .red,
+      corners: [.bottomLeft, .topRight])
+  payButton.borderStyle = payButtonBorder
+  paymentFormStyle.payButton = payButton
+}
+
 // Change Payment button text
 paymentFormStyle.payButton.text = "Pay £54.63"
 ```


### PR DESCRIPTION
- Adding entry in ChangeLog for new release
- Proposing ReadMe update to convey possible behaviour enabled by the borders work

ReadMe code change produces the following outcome with Default:
<img width="334" alt="Screenshot 2023-06-27 at 10 33 27" src="https://github.com/checkout/frames-ios/assets/102028170/f77bf97d-538b-454f-b918-5350d12df630">
