### PR TITLE
Add test cases for every card scheme's security code verifications

### DIFF
--- a/iOS Example Frame SPM/iOS Example Frame Regression Tests/Helpers/StaticTexts.swift
+++ b/iOS Example Frame SPM/iOS Example Frame Regression Tests/Helpers/StaticTexts.swift
@@ -10,4 +10,5 @@ import Foundation
 
 enum StaticTexts {
     static let cardNumberNotValidError = "Please enter a valid card number"
+    static let securityCodeNotValidError = "Please enter a valid security code"
 }

--- a/iOS Example Frame SPM/iOS Example Frame Regression Tests/Helpers/TestCard.swift
+++ b/iOS Example Frame SPM/iOS Example Frame Regression Tests/Helpers/TestCard.swift
@@ -12,7 +12,7 @@ enum CardType {
     case visa, mastercard,amex, maestro, jcb, diners, discover, mada
 }
 
-struct TestCard {
+struct TestCard: Hashable {
     let type: CardType
     let number: String
     var securityCode: String = "123"


### PR DESCRIPTION
Tests if we verify the security code lengths depending on the requirements of the card schemes.