### PR TITLE
PIMOB 2058 - expiry date validation

### DIFF
--- a/Source/UI/PaymentForm/View/ExpiryDate/ExpiryDateFormatter.swift
+++ b/Source/UI/PaymentForm/View/ExpiryDate/ExpiryDateFormatter.swift
@@ -45,7 +45,7 @@ struct ExpiryDateFormatter {
     /// If the cardScheme is `unknown`, this validates that the cvv is conforming to internal generic standards
     /// - Parameters:
     ///   - input: The input as received from the user facing UI component
-    /// - Returns: Tuple made of a formatted input for displaying to the user and an error if presented input is not valid.
+    /// - Returns: A formatted input for displaying to the user and nil if presented input is not valid.
     /// If displayString is nil, the text in the UI component should be rejected at last valid input should be maintained!
     func formatForDisplay(input: String) -> String? {
         guard input.count <= dateFormatTextCount else {

--- a/Source/UI/PaymentForm/View/ExpiryDate/ExpiryDateFormatter.swift
+++ b/Source/UI/PaymentForm/View/ExpiryDate/ExpiryDateFormatter.swift
@@ -22,19 +22,22 @@ struct ExpiryDateFormatter {
         self.cardValidator = cardValidator
     }
 
-    func createCardExpiry(from input: String) -> Result<ExpiryDate, ExpiryDateError> {
+    func createCardExpiry(from input: String) -> Result<ExpiryDate, ValidationError.ExpiryDate> {
         let components = getComponents(from: input)
-        guard let month = components.month,
-              let year = components.year else {
-            return .failure(.invalidCode)
+        guard let month = components.month else {
+            return .failure(.invalidMonth)
+        }
+
+        guard let year = components.year else {
+            return .failure(.invalidYear)
         }
 
         let validationOutcome = cardValidator.validate(expiryMonth: month, expiryYear: year)
         switch validationOutcome {
         case .success(let expiryDate):
             return .success(expiryDate)
-        case .failure:
-            return .failure(.invalidCode)
+        case .failure(let error):
+            return .failure(error)
         }
     }
 
@@ -44,14 +47,14 @@ struct ExpiryDateFormatter {
     ///   - input: The input as received from the user facing UI component
     /// - Returns: Tuple made of a formatted input for displaying to the user and an error if presented input is not valid.
     /// If displayString is nil, the text in the UI component should be rejected at last valid input should be maintained!
-    func formatForDisplay(input: String) -> (displayString: String?, validationError: ValidationError.ExpiryDate?) {
+    func formatForDisplay(input: String) -> String? {
         guard input.count <= dateFormatTextCount else {
-            return (nil, nil)
+            return nil
         }
         let (month, year) = getComponents(from: input)
 
         guard let month else {
-            return (nil, nil)
+            return nil
         }
         var displayString = ""
         if month.count == 1 {
@@ -62,7 +65,7 @@ struct ExpiryDateFormatter {
 
         guard let year,
               let yearInt = Int(year) else {
-            return (displayString, nil)
+            return displayString
         }
 
         displayString += year
@@ -72,15 +75,15 @@ struct ExpiryDateFormatter {
         if year.count == 1 {
             let currentDecade = Int(currentYearLast2Digits / 10)
             if yearInt < currentDecade {
-                return (displayString, .inThePast)
+                return displayString
             } else {
-                return (displayString, nil)
+                return displayString
             }
         }
         if yearInt < currentYearLast2Digits {
-            return (displayString, .inThePast)
+            return displayString
         } else {
-            return (displayString, nil)
+            return displayString
         }
     }
 

--- a/Source/UI/PaymentForm/View/ExpiryDate/ExpiryDateView.swift
+++ b/Source/UI/PaymentForm/View/ExpiryDate/ExpiryDateView.swift
@@ -1,12 +1,8 @@
 import UIKit
 import Checkout
 
-enum ExpiryDateError: Error {
-  case invalidCode
-}
-
 protocol ExpiryDateViewDelegate: AnyObject {
-  func update(result: Result<ExpiryDate, ExpiryDateError>)
+  func update(result: Result<ExpiryDate, ValidationError.ExpiryDate>)
 }
 
 final class ExpiryDateView: UIView {
@@ -59,7 +55,7 @@ extension ExpiryDateView: TextFieldViewDelegate {
     guard textField.text?.count ?? 0 != dateFormatter.dateFormatTextCount else {
       return true
     }
-    let (displayValue, _) = dateFormatter.formatForDisplay(input: textField.text ?? "")
+    let displayValue = dateFormatter.formatForDisplay(input: textField.text ?? "")
     updateErrorViewStyle(isHidden: false,
                          textfieldText: displayValue,
                          error: .incompleteYear)
@@ -74,9 +70,6 @@ extension ExpiryDateView: TextFieldViewDelegate {
   func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
     let outputText = textField.replacingCharacters(in: range, with: string) ?? ""
 
-    defer {
-      delegate?.update(result: dateFormatter.createCardExpiry(from: outputText))
-    }
     // If string is empty when this is called, it means there was no character added to the change
     // meaning it is a deletion. We will not reformat a deletion as we risk to block user
     // We will just allow TextField to do its lifecycle and record modified value
@@ -87,18 +80,29 @@ extension ExpiryDateView: TextFieldViewDelegate {
 
     // When the input is changed we will reformat it for display, notifying its consumers
     // of the new value
-    let (displayValue, error) = dateFormatter.formatForDisplay(input: outputText)
+    let displayValue = dateFormatter.formatForDisplay(input: outputText)
 
     // Receiving nil from the formatting means the new input is invalid and we should not accept it,
     // dropping it completely
     guard displayValue != nil else {
       return false
     }
-    updateErrorViewStyle(isHidden: error == nil,
-                         textfieldText: displayValue,
-                         error: error)
-    // As we notify consumers, we already update the input value, so we do not want
-    // the lifecycle to duplicate the update
+
+    let validationResult = dateFormatter.createCardExpiry(from: outputText)
+    delegate?.update(result: validationResult)
+
+    switch validationResult {
+    case .success:
+        updateErrorViewStyle(isHidden: true,
+                              textfieldText: displayValue,
+                              error: nil)
+
+    case .failure(let error):
+        updateErrorViewStyle(isHidden: false,
+                               textfieldText: displayValue,
+                               error: error)
+    }
+
     return false
   }
 }

--- a/Source/UI/PaymentForm/View/ExpiryDate/ExpiryDateView.swift
+++ b/Source/UI/PaymentForm/View/ExpiryDate/ExpiryDateView.swift
@@ -70,6 +70,9 @@ extension ExpiryDateView: TextFieldViewDelegate {
   func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
     let outputText = textField.replacingCharacters(in: range, with: string) ?? ""
 
+    let validationResult = dateFormatter.createCardExpiry(from: outputText)
+    delegate?.update(result: validationResult)
+
     // If string is empty when this is called, it means there was no character added to the change
     // meaning it is a deletion. We will not reformat a deletion as we risk to block user
     // We will just allow TextField to do its lifecycle and record modified value
@@ -87,9 +90,6 @@ extension ExpiryDateView: TextFieldViewDelegate {
     guard displayValue != nil else {
       return false
     }
-
-    let validationResult = dateFormatter.createCardExpiry(from: outputText)
-    delegate?.update(result: validationResult)
 
     switch validationResult {
     case .success:

--- a/Source/UI/PaymentForm/ViewController/PaymentViewController.swift
+++ b/Source/UI/PaymentForm/ViewController/PaymentViewController.swift
@@ -4,7 +4,7 @@ import Checkout
 protocol PaymentViewControllerDelegate: AnyObject {
   func addBillingButtonIsPressed(sender: UINavigationController?)
   func editBillingButtonIsPressed(sender: UINavigationController?)
-  func expiryDateIsUpdated(result: Result<ExpiryDate, ExpiryDateError>)
+  func expiryDateIsUpdated(result: Result<ExpiryDate, ValidationError.ExpiryDate>)
   func securityCodeIsUpdated(to newCode: String)
   func cardholderIsUpdated(value: String)
   func payButtonIsPressed()
@@ -400,7 +400,7 @@ extension PaymentViewController: BillingFormSummaryViewDelegate {
 }
 
 extension PaymentViewController: ExpiryDateViewDelegate {
-  func update(result: Result<ExpiryDate, ExpiryDateError>) {
+  func update(result: Result<ExpiryDate, ValidationError.ExpiryDate>) {
     delegate?.expiryDateIsUpdated(result: result)
   }
 }

--- a/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
+++ b/Source/UI/PaymentForm/ViewModel/DefaultPaymentViewModel.swift
@@ -157,7 +157,7 @@ extension DefaultPaymentViewModel: BillingFormViewModelDelegate {
 }
 
 extension DefaultPaymentViewModel: PaymentViewControllerDelegate {
-    func expiryDateIsUpdated(result: Result<ExpiryDate, ExpiryDateError>) {
+    func expiryDateIsUpdated(result: Result<ExpiryDate, ValidationError.ExpiryDate>) {
         switch result {
         case .failure:
             cardDetails.expiryDate = nil

--- a/Tests/Mocks/MockExpiryDateViewDelegate.swift
+++ b/Tests/Mocks/MockExpiryDateViewDelegate.swift
@@ -11,9 +11,9 @@ import Checkout
 
 final class MockExpiryDateViewDelegate: ExpiryDateViewDelegate {
     
-    var receivedResults = [Result<Checkout.ExpiryDate, Frames.ExpiryDateError>]()
+    var receivedResults = [Result<Checkout.ExpiryDate, ValidationError.ExpiryDate>]()
     
-    func update(result: Result<Checkout.ExpiryDate, Frames.ExpiryDateError>) {
+    func update(result: Result<Checkout.ExpiryDate, ValidationError.ExpiryDate>) {
         receivedResults.append(result)
     }
     

--- a/Tests/Mocks/PaymentViewControllerMockDelegate.swift
+++ b/Tests/Mocks/PaymentViewControllerMockDelegate.swift
@@ -14,7 +14,7 @@ class PaymentViewControllerMockDelegate: PaymentViewControllerDelegate {
 
   var addBillingButtonIsPressedWithSender: [UINavigationController?] = []
   var editBillingButtonIsPressedWithSender: [UINavigationController?] = []
-  var expiryDateIsUpdatedWithValue: [Result<ExpiryDate, ExpiryDateError>] = []
+  var expiryDateIsUpdatedWithValue: [Result<ExpiryDate, ValidationError.ExpiryDate>] = []
   var securityCodeIsUpdatedWithValue: [String] = []
   var cardholderIsUpdatedWithValue: [String] = []
   var payButtonIsPressedCounter: Int = 0
@@ -28,7 +28,7 @@ class PaymentViewControllerMockDelegate: PaymentViewControllerDelegate {
     editBillingButtonIsPressedWithSender.append(sender)
   }
 
-  func expiryDateIsUpdated(result: Result<ExpiryDate, ExpiryDateError>) {
+  func expiryDateIsUpdated(result: Result<ExpiryDate, ValidationError.ExpiryDate>) {
     expiryDateIsUpdatedWithValue.append(result)
   }
 

--- a/Tests/UI/BillingForm/View/ExpiryDateFormatterTests.swift
+++ b/Tests/UI/BillingForm/View/ExpiryDateFormatterTests.swift
@@ -29,184 +29,166 @@ final class ExpiryDateFormatterTests: XCTestCase {
     func testInvalidStringInput() {
         let testInput = "agedasve"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertNil(output.displayString)
-        XCTAssertNil(output.validationError)
+        XCTAssertNil(displayString)
     }
 
     func testInvalidCharacterInput() {
         let testInput = "g"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertNil(output.displayString)
-        XCTAssertNil(output.validationError)
+        XCTAssertNil(displayString)
     }
 
     func testInvalidNumberInput() {
         let testInput = "0145"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertNil(output.displayString)
-        XCTAssertNil(output.validationError)
+        XCTAssertNil(displayString)
     }
 
     func testWrongFormatDateInput() {
         let testInput = "01/2088"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertNil(output.displayString)
-        XCTAssertNil(output.validationError)
+        XCTAssertNil(displayString)
     }
 
     func testValidSingleDigitInput() {
         let testInput = "0"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertEqual(output.displayString, "0")
-        XCTAssertNil(output.validationError)
+        XCTAssertEqual(displayString, "0")
     }
 
     func testInvalidSingleDigitInput() {
         let testInput = "2"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertEqual(output.displayString, "02/")
-        XCTAssertNil(output.validationError)
+        XCTAssertEqual(displayString, "02/")
     }
 
     func testInvalidMonthInput() {
         let testInput = "14"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertNil(output.displayString)
-        XCTAssertNil(output.validationError)
+        XCTAssertNil(displayString)
     }
 
     func testValidMonthInput() {
         let testInput = "11"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertEqual(output.displayString, "11/")
-        XCTAssertNil(output.validationError)
+        XCTAssertEqual(displayString, "11/")
     }
 
     func testValidMonthInputWithSlash() {
         let testInput = "11/"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertEqual(output.displayString, "11/")
-        XCTAssertNil(output.validationError)
+        XCTAssertEqual(displayString, "11/")
     }
 
     func testValidMonthAndPastDecadeInput() {
         let testInput = "11/1"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertEqual(output.displayString, "11/1")
-        XCTAssertEqual(output.validationError, .inThePast)
+        XCTAssertEqual(displayString, "11/1")
     }
 
     func testValidMonthAndFutureDecadeDigitInput() {
         let testInput = "11/8"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertEqual(output.displayString, "11/8")
-        XCTAssertNil(output.validationError)
+        XCTAssertEqual(displayString, "11/8")
     }
 
     func testValidMonthAndFullPastYearInput() {
         let testInput = "11/21"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertEqual(output.displayString, "11/21")
-        XCTAssertEqual(output.validationError, .inThePast)
+        XCTAssertEqual(displayString, "11/21")
     }
 
     func testValidMonthAndFullValidYearInput() {
         let testInput = "11/88"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertEqual(output.displayString, "11/88")
-        XCTAssertNil(output.validationError)
+        XCTAssertEqual(displayString, "11/88")
     }
 
     func testIncompleteMonthAndFullYearInput() {
         let testInput = "2/88"
         let formatter = ExpiryDateFormatter()
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertEqual(output.displayString, "02/88")
-        XCTAssertNil(output.validationError)
+        XCTAssertEqual(displayString, "02/88")
     }
 
     func testMixedNumberAndDigitInput() {
         let formatter = ExpiryDateFormatter()
         var testInput = "0k/8l"
-        var testOutcome = formatter.formatForDisplay(input: testInput)
-        XCTAssertEqual(testOutcome.displayString, "0")
-        XCTAssertNil(testOutcome.validationError)
+        var displayString = formatter.formatForDisplay(input: testInput)
+        XCTAssertEqual(displayString, "0")
 
         testInput = "1k/8l"
-        testOutcome = formatter.formatForDisplay(input: testInput)
-        XCTAssertEqual(testOutcome.displayString, "1")
-        XCTAssertNil(testOutcome.validationError)
+        displayString = formatter.formatForDisplay(input: testInput)
+        XCTAssertEqual(displayString, "1")
 
         testInput = "4k/8l"
-        testOutcome = formatter.formatForDisplay(input: testInput)
-        XCTAssertEqual(testOutcome.displayString, "04/8")
-        XCTAssertNil(testOutcome.validationError)
+        displayString = formatter.formatForDisplay(input: testInput)
+        XCTAssertEqual(displayString, "04/8")
     }
 
     func testChangedDateSeparator() {
         let newSeparator = " - "
         let testInput = "12\(newSeparator)67"
         let formatter = ExpiryDateFormatter(componentSeparator: newSeparator)
-        let output = formatter.formatForDisplay(input: testInput)
+        let displayString = formatter.formatForDisplay(input: testInput)
 
-        XCTAssertEqual(output.displayString, "12\(newSeparator)67")
-        XCTAssertNil(output.validationError)
+        XCTAssertEqual(displayString, "12\(newSeparator)67")
     }
 
     // MARK: Create Card Expiry Tests
     func testCreateCardExpiryWithEmptyString() {
         let testString = ""
         let formatter = ExpiryDateFormatter()
-        let outcome = formatter.createCardExpiry(from: testString)
-        XCTAssertEqual(outcome, .failure(.invalidCode))
+        let displayString = formatter.createCardExpiry(from: testString)
+        XCTAssertEqual(displayString, .failure(.invalidMonth))
     }
 
     func testCreateCardExpiryWithInvalidInput() {
         let testString = "iojfehnuw43wekjs"
         let formatter = ExpiryDateFormatter()
-        let outcome = formatter.createCardExpiry(from: testString)
-        XCTAssertEqual(outcome, .failure(.invalidCode))
+        let displayString = formatter.createCardExpiry(from: testString)
+        XCTAssertEqual(displayString, .failure(.invalidMonth))
     }
 
     func testCreateCardExpiryWithMisformatedInput() {
         let testString = "1026"
         let formatter = ExpiryDateFormatter()
-        let outcome = formatter.createCardExpiry(from: testString)
-        XCTAssertEqual(outcome, .failure(.invalidCode))
+        let displayString = formatter.createCardExpiry(from: testString)
+        XCTAssertEqual(displayString, .failure(.invalidMonth))
     }
 
     func testCreateCardExpiryWithMixedNumberAndDigitInput() {
         let testString = "0a/8g"
         let formatter = ExpiryDateFormatter()
-        let outcome = formatter.createCardExpiry(from: testString)
-        XCTAssertEqual(outcome, .failure(.invalidCode))
+        let displayString = formatter.createCardExpiry(from: testString)
+        XCTAssertEqual(displayString, .failure(.invalidYear))
     }
 
     func testCreateCardUsesCardValidatorOutcome() {
@@ -216,7 +198,7 @@ final class ExpiryDateFormatterTests: XCTestCase {
         var testString = "01/45"
         mockValidator.validateExpiryStringToReturn = .failure(.incompleteMonth)
         var outcome = formatter.createCardExpiry(from: testString)
-        XCTAssertEqual(outcome, .failure(.invalidCode))
+        XCTAssertEqual(outcome, .failure(.incompleteMonth))
         XCTAssertEqual(mockValidator.validateExpiryStringCalledWith?.expiryMonth, "01")
         XCTAssertEqual(mockValidator.validateExpiryStringCalledWith?.expiryYear, "45")
 

--- a/Tests/UI/BillingForm/View/ExpiryDateViewTests.swift
+++ b/Tests/UI/BillingForm/View/ExpiryDateViewTests.swift
@@ -45,7 +45,7 @@ class ExpiryDateViewTests: XCTestCase {
         view.delegate = mockDelegate
         let textField = UITextField()
         textField.text = dateText
-        XCTAssertTrue(view.textField(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 0), replacementString: ""))
+        XCTAssertFalse(view.textField(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 5), replacementString: dateText))
         XCTAssertTrue(view.style?.error?.isHidden == true)
         XCTAssertEqual(view.style?.textfield.text, dateText)
         
@@ -72,7 +72,7 @@ class ExpiryDateViewTests: XCTestCase {
         XCTAssertEqual(mockDelegate.receivedResults.count, 1)
         switch mockDelegate.receivedResults.first {
         case .failure(let error):
-            XCTAssertEqual(error, .invalidCode)
+            XCTAssertEqual(error, .inThePast)
         default:
             XCTFail("Should call delegate with a failure!")
         }


### PR DESCRIPTION
`CardValidator` was solid and was returning the error but `ExpiryDateFormatter` was not using that error information and also was overriding any kinds of errors that was being propagated through. 

This PR uses a central point of verification for expiry date validation and depends on CardValidator only.