### PR TITLE
Card validator improvement

### DIFF
--- a/Checkout/Checkout/Source/Extension/Foundation+Extensions.swift
+++ b/Checkout/Checkout/Source/Extension/Foundation+Extensions.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
-extension Calendar: CalendarProtocol { }
+extension Calendar: CalendarProtocol {
+    func current() -> Date {
+        Date()
+    }
+}
+
 extension JSONEncoder: Encoding { }
 extension JSONDecoder: Decoding { }

--- a/Checkout/Checkout/Source/Protocols/CalendarProtocol.swift
+++ b/Checkout/Checkout/Source/Protocols/CalendarProtocol.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol CalendarProtocol {
+protocol CalendarProtocol: DateProviding {
   func date(from components: DateComponents) -> Date?
   func date(byAdding component: Calendar.Component, value: Int, to date: Date, wrappingComponents: Bool) -> Date?
   func component(_ component: Calendar.Component, from date: Date) -> Int

--- a/Checkout/Checkout/Source/Validation/Validators/CardValidator.swift
+++ b/Checkout/Checkout/Source/Validation/Validators/CardValidator.swift
@@ -224,7 +224,7 @@ public class CardValidator: CardValidating {
       return .failure(.invalidMonth)
     }
 
-    let currentDate = Date()
+    let currentDate = calendar.current()
     // using UTC-12 as this is the latest timezone where a card could be valid
     let cardExpiryComponents = DateComponents(
       timeZone: .utcMinus12,

--- a/CheckoutTests/Stubs/StubCalendar.swift
+++ b/CheckoutTests/Stubs/StubCalendar.swift
@@ -9,12 +9,23 @@ import Foundation
 @testable import Checkout
 
 final class StubCalendar: CalendarProtocol {
+  var currentDateToReturn: Date?
+
+  func current() -> Date {
+    currentDateToReturn ?? Date()
+  }
+
+  var forceToReturnNilComponents: Bool = false
   var dateFromComponentsToReturn: Date?
   private(set) var dateFromComponentsCalledWith: DateComponents?
 
   func date(from components: DateComponents) -> Date? {
     dateFromComponentsCalledWith = components
-    return dateFromComponentsToReturn
+
+    if forceToReturnNilComponents {
+    return nil
+    }
+    return dateFromComponentsToReturn ?? Calendar(identifier: .gregorian).date(from: components)
   }
 
   var dateByAddingOverride = true


### PR DESCRIPTION
Card validator tests were not actually testing anything. They needed a custom way to get a pre defined date. 

This will also help us to override the system time and test expiry date edge cases in the upcoming automated regression tests.