### PR TITLE
Exclude sample projects from package distribution

### DIFF
--- a/Checkout/Samples/Package.swift
+++ b/Checkout/Samples/Package.swift
@@ -1,0 +1,5 @@
+// swift-tools-version:5.6
+// THIS IS TO EXCLUDE SAMPLE PROJECTS FROM PACKAGE DISTRIBUTION
+import PackageDescription
+let package = Package()
+// THIS IS TO EXCLUDE SAMPLE PROJECTS FROM PACKAGE DISTRIBUTION

--- a/iOS Example Frame SPM/Package.swift
+++ b/iOS Example Frame SPM/Package.swift
@@ -1,0 +1,5 @@
+// swift-tools-version:5.6
+// THIS IS TO EXCLUDE SAMPLE PROJECTS FROM PACKAGE DISTRIBUTION
+import PackageDescription
+let package = Package()
+// THIS IS TO EXCLUDE SAMPLE PROJECTS FROM PACKAGE DISTRIBUTION

--- a/iOS Example Frame/Package.swift
+++ b/iOS Example Frame/Package.swift
@@ -1,0 +1,5 @@
+// swift-tools-version:5.6
+// THIS IS TO EXCLUDE SAMPLE PROJECTS FROM PACKAGE DISTRIBUTION
+import PackageDescription
+let package = Package()
+// THIS IS TO EXCLUDE SAMPLE PROJECTS FROM PACKAGE DISTRIBUTION


### PR DESCRIPTION
<img width="269" alt="Screenshot 2023-08-03 at 21 25 04" src="https://github.com/checkout/frames-ios/assets/125963311/ca076217-eeb7-4473-afbe-7abe0e3f4c68">

Merchants don't need to download our sample projects into their application bundle. Especially after the addition of many snapshots. This PR removes them. The only working way of achieving this is adding empty `Package.swift` files as the other ways don't work.