### PR TITLE
Fix bitrise yml

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -170,20 +170,20 @@ workflows:
     before_run:
     - _frames-set-up
 
-  _run-integration-tests:
+  _run-regression-tests:
     steps:
     - xcode-test:
         inputs:
         - project_path: $FRAMES_SPM_PROJECT
-        - scheme: $FRAMES_INTEGRATION_TEST_SCHEME
+        - scheme: $FRAMES_REGRESSION_TEST_SCHEME
         - simulator_device: $UITEST_SIMULATOR_DEVICE
     - deploy-to-bitrise-io@1: {}
     - cache-push@2: {}
 
-  frames-integration-tests:
+  frames-regression-tests:
     after_run:
     - _frames-set-up
-    - _run-integration-tests
+    - _run-regression-tests
 
 app:
   envs:
@@ -213,7 +213,7 @@ app:
     FRAMES_UITEST_SCHEME: UITest
   - opts:
       is_expand: false
-    FRAMES_INTEGRATION_TEST_SCHEME: Integration Tests
+    FRAMES_REGRESSION_TEST_SCHEME: Regression Tests
   - opts:
       is_expand: false
     CARTHAGE_XCFRAMEWORK: '--use-xcframeworks --platform iOS --cache-builds'


### PR DESCRIPTION
We had renamed integration tests to regression tests, therefore, we needed to update the name of the workflow on main branch since Bitrise gets the config from main.