### PR TITLE
Bump version to 4.1.1

### DIFF
--- a/Checkout.podspec
+++ b/Checkout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Checkout'
-  s.version = '4.1.0'
+  s.version = '4.1.1'
   s.summary = 'Checkout SDK for iOS'
 
   s.description = <<-DESC

--- a/Checkout/Checkout/Source/Validation/Constants.swift
+++ b/Checkout/Checkout/Source/Validation/Constants.swift
@@ -25,7 +25,7 @@ public enum Constants {
     }
 
   enum Product {
-    static let version = "4.1.0"
+    static let version = "4.1.1"
     static let name = "checkout-ios-sdk"
     static let userAgent = "checkout-sdk-ios/\(version)"
   }

--- a/CheckoutTests/Network/RequestFactoryTests.swift
+++ b/CheckoutTests/Network/RequestFactoryTests.swift
@@ -58,7 +58,7 @@ final class RequestFactoryTests: XCTestCase {
       XCTAssertEqual(requestParameters.url, URL(string: "https://www.checkout.com/tokens"))
       XCTAssertEqual(requestParameters.additionalHeaders, [
         "Authorization": "Bearer publicKey",
-        "User-Agent": "checkout-sdk-ios/4.1.0"
+        "User-Agent": "checkout-sdk-ios/4.1.1"
       ])
       XCTAssertEqual(requestParameters.contentType, "application/json;charset=UTF-8")
       XCTAssertEqual(requestParameters.timeout, 30)
@@ -91,7 +91,7 @@ final class RequestFactoryTests: XCTestCase {
       XCTAssertEqual(requestParameters.url, URL(string: "https://www.checkout.com/tokens"))
       XCTAssertEqual(requestParameters.additionalHeaders, [
         "Authorization": "Bearer publicKey",
-        "User-Agent": "checkout-sdk-ios/4.1.0"
+        "User-Agent": "checkout-sdk-ios/4.1.1"
       ])
       XCTAssertEqual(requestParameters.contentType, "application/json;charset=UTF-8")
       XCTAssertEqual(requestParameters.timeout, 30)

--- a/Frames.podspec
+++ b/Frames.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Frames"
-  s.version      = "4.1.0"
+  s.version      = "4.1.1"
   s.summary      = "Checkout API Client, Payment Form UI and Utilities in Swift"
   s.description  = <<-DESC
   Checkout API Client and Payment Form Utilities in Swift.
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'PhoneNumberKit'
   s.dependency 'CheckoutEventLoggerKit', '~> 1.2.4'
-  s.dependency 'Checkout', '4.1.0'
+  s.dependency 'Checkout', '4.1.1'
 
 end


### PR DESCRIPTION
Release 4.1.1 with the latest expiry date hotfixes