### PR TITLE
Bump version to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 
 #### 4.x Releases
 
+## [4.2.0](https://github.com/checkout/frames-ios/releases/tag/4.2.0)
+
+Released on 2023-08-15
+
+Updates:
+
+- Structural non-breaking changes to the project
+- Carthage support and sample projects are removed
+- Sample projects for SPM and Cocoapods are removed from the SPM distribution
+- Automated regression tests and snapshot tests are added 
+
+
+## [4.1.1](https://github.com/checkout/frames-ios/releases/tag/4.1.1)
+
+Released on 2023-08-10
+
+Updates:
+
+- Fixes an error that validates expiry date when the date input is in the same year but on a previous month
+
 ## [4.1.0](https://github.com/checkout/frames-ios/releases/tag/4.1.0)
 
 Released on 2023-06-27

--- a/Checkout/Checkout.podspec
+++ b/Checkout/Checkout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Checkout'
-  s.version = '4.1.0'
+  s.version = '4.2.0'
   s.summary = 'Checkout SDK for iOS'
 
   s.description = <<-DESC

--- a/Checkout/Source/Validation/Constants.swift
+++ b/Checkout/Source/Validation/Constants.swift
@@ -25,7 +25,7 @@ public enum Constants {
     }
 
   enum Product {
-    static let version = "4.1.1"
+    static let version = "4.2.0"
     static let name = "checkout-ios-sdk"
     static let userAgent = "checkout-sdk-ios/\(version)"
   }

--- a/CheckoutTests/Network/RequestFactoryTests.swift
+++ b/CheckoutTests/Network/RequestFactoryTests.swift
@@ -58,7 +58,7 @@ final class RequestFactoryTests: XCTestCase {
       XCTAssertEqual(requestParameters.url, URL(string: "https://www.checkout.com/tokens"))
       XCTAssertEqual(requestParameters.additionalHeaders, [
         "Authorization": "Bearer publicKey",
-        "User-Agent": "checkout-sdk-ios/4.1.1"
+        "User-Agent": "checkout-sdk-ios/\(Constants.Product.version)"
       ])
       XCTAssertEqual(requestParameters.contentType, "application/json;charset=UTF-8")
       XCTAssertEqual(requestParameters.timeout, 30)
@@ -91,7 +91,7 @@ final class RequestFactoryTests: XCTestCase {
       XCTAssertEqual(requestParameters.url, URL(string: "https://www.checkout.com/tokens"))
       XCTAssertEqual(requestParameters.additionalHeaders, [
         "Authorization": "Bearer publicKey",
-        "User-Agent": "checkout-sdk-ios/4.1.1"
+        "User-Agent": "checkout-sdk-ios/\(Constants.Product.version)"
       ])
       XCTAssertEqual(requestParameters.contentType, "application/json;charset=UTF-8")
       XCTAssertEqual(requestParameters.timeout, 30)

--- a/Frames.podspec
+++ b/Frames.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Frames"
-  s.version      = "4.1.1"
+  s.version      = "4.2.0"
   s.summary      = "Checkout API Client, Payment Form UI and Utilities in Swift"
   s.description  = <<-DESC
   Checkout API Client and Payment Form Utilities in Swift.
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'PhoneNumberKit'
   s.dependency 'CheckoutEventLoggerKit', '~> 1.2.4'
-  s.dependency 'Checkout', '4.1.1'
+  s.dependency 'Checkout', '4.2.0'
 
 end

--- a/Source/Core/Constants/Constants.swift
+++ b/Source/Core/Constants/Constants.swift
@@ -8,7 +8,7 @@
 enum Constants {
 
     static let productName = "frames-ios-sdk"
-    static let version = "4.1.0"
+    static let version = "4.2.0"
     static let userAgent = "checkout-sdk-frames-ios/\(version)"
 
     enum Logging {


### PR DESCRIPTION
- Structural changes
- Carthage support and sample project removal
- Automated regression tests
- Removal of the sample projects from the SPM distribution (they were already excluded on CocoaPods distribution)