### PR TITLE
Rename PaymentViewController

### DIFF
--- a/CheckoutTests/Integration/CheckoutAPIServiceIntegrationTests.swift
+++ b/CheckoutTests/Integration/CheckoutAPIServiceIntegrationTests.swift
@@ -139,7 +139,7 @@ final class CheckoutAPIServiceIntegrationTests: XCTestCase {
         XCTAssertNil(tokenDetails.billingAddress)
         XCTAssertEqual(tokenDetails.cardCategory, "CONSUMER")
         XCTAssertEqual(tokenDetails.cardType, "DEBIT")
-        XCTAssertEqual(tokenDetails.issuer, "CURVE UK LIMITED")
+        XCTAssertEqual(tokenDetails.issuer, "WISE PAYMENTS LIMITED")
         XCTAssertEqual(tokenDetails.issuerCountry, "GB")
         XCTAssertNil(tokenDetails.phone)
         XCTAssertEqual(tokenDetails.productId, "MDW")

--- a/Source/UI/PaymentForm/Factory/PaymentFormFactory.swift
+++ b/Source/UI/PaymentForm/Factory/PaymentFormFactory.swift
@@ -19,7 +19,7 @@ public enum PaymentFormFactory {
                                                 supportedSchemes: configuration.supportedSchemes)
         viewModel.preventDuplicateCardholderInput()
 
-        let viewController = PaymentViewController(viewModel: viewModel)
+        let viewController = FramesPaymentViewController(viewModel: viewModel)
         viewModel.cardTokenRequested = completionHandler
         logger.log(.paymentFormInitialised(environment: configuration.environment))
         if #available(iOS 13.0, *) {

--- a/Source/UI/PaymentForm/ViewController/FramesPaymentViewController.swift
+++ b/Source/UI/PaymentForm/ViewController/FramesPaymentViewController.swift
@@ -11,7 +11,7 @@ protocol PaymentViewControllerDelegate: AnyObject {
 }
 
 // swiftlint:disable file_length
-final class PaymentViewController: UIViewController {
+final class FramesPaymentViewController: UIViewController {
 
   // MARK: - Variables
 
@@ -173,7 +173,7 @@ final class PaymentViewController: UIViewController {
 
 // MARK: View Model Integration
 
-extension PaymentViewController {
+extension FramesPaymentViewController {
   private func setupViewModel() {
     delegate = self.viewModel as? PaymentViewControllerDelegate
     updateBackgroundViews()
@@ -323,7 +323,7 @@ extension PaymentViewController {
 
 // MARK: Setup Views
 
-extension PaymentViewController {
+extension FramesPaymentViewController {
   private func setupViewsInOrder() {
     setupScrollView()
     setupStackView()
@@ -387,43 +387,43 @@ extension PaymentViewController {
   }
 }
 
-extension PaymentViewController: SelectionButtonViewDelegate {
+extension FramesPaymentViewController: SelectionButtonViewDelegate {
   func selectionButtonIsPressed() {
     delegate?.addBillingButtonIsPressed(sender: navigationController)
   }
 }
 
-extension PaymentViewController: BillingFormSummaryViewDelegate {
+extension FramesPaymentViewController: BillingFormSummaryViewDelegate {
   func summaryButtonIsPressed() {
     delegate?.editBillingButtonIsPressed(sender: navigationController)
   }
 }
 
-extension PaymentViewController: ExpiryDateViewDelegate {
+extension FramesPaymentViewController: ExpiryDateViewDelegate {
   func update(result: Result<ExpiryDate, ValidationError.ExpiryDate>) {
     delegate?.expiryDateIsUpdated(result: result)
   }
 }
 
-extension PaymentViewController: CardholderDelegate {
+extension FramesPaymentViewController: CardholderDelegate {
   func cardholderUpdated(to cardholderInput: String) {
     delegate?.cardholderIsUpdated(value: cardholderInput)
   }
 }
 
-extension PaymentViewController: SecurityCodeViewDelegate {
+extension FramesPaymentViewController: SecurityCodeViewDelegate {
   func update(securityCode: String) {
     delegate?.securityCodeIsUpdated(to: securityCode)
   }
 }
 
-extension PaymentViewController: ButtonViewDelegate {
+extension FramesPaymentViewController: ButtonViewDelegate {
   func selectionButtonIsPressed(sender: UIView) {
     delegate?.payButtonIsPressed()
   }
 }
 
-extension PaymentViewController: UIScrollViewDelegate {
+extension FramesPaymentViewController: UIScrollViewDelegate {
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
     let contentOffsetY = scrollView.contentOffset.y + scrollView.adjustedContentInset.top
 

--- a/Tests/UI/Factory/FramesFactoryTests.swift
+++ b/Tests/UI/Factory/FramesFactoryTests.swift
@@ -30,7 +30,7 @@ class FramesFactoryTests: XCTestCase {
     let formConfig = PaymentFormConfiguration(apiKey: "", environment: .sandbox, supportedSchemes: [.visa], billingFormData: billingForm)
     let formStyle = PaymentStyle(paymentFormStyle: paymentFormStyle, billingFormStyle: billingFormStyle)
     let viewController = PaymentFormFactory.buildViewController(configuration: formConfig, style: formStyle) { _ in }
-    let paymentViewController = try XCTUnwrap(viewController as? PaymentViewController)
+    let paymentViewController = try XCTUnwrap(viewController as? FramesPaymentViewController)
     let viewModel = try XCTUnwrap(paymentViewController.viewModel)
 
     XCTAssertNotNil(paymentViewController.viewModel)

--- a/Tests/UI/PaymentForm/PaymentViewControllerTests.swift
+++ b/Tests/UI/PaymentForm/PaymentViewControllerTests.swift
@@ -10,7 +10,7 @@ import Checkout
 @testable import Frames
 
 class PaymentViewControllerTests: XCTestCase {
-  var viewController: PaymentViewController!
+  var viewController: FramesPaymentViewController!
   var viewModel: DefaultPaymentViewModel!
   let delegate = PaymentViewControllerMockDelegate()
   let stubCheckoutAPIService = StubCheckoutAPIService()
@@ -34,7 +34,7 @@ class PaymentViewControllerTests: XCTestCase {
                                         paymentFormStyle: DefaultPaymentFormStyle(),
                                         billingFormStyle: DefaultBillingFormStyle(),
                                         supportedSchemes: [.discover, .mada])
-    viewController = PaymentViewController(viewModel: viewModel)
+    viewController = FramesPaymentViewController(viewModel: viewModel)
   }
   
   func testPaymentViewsHierarchy() {
@@ -155,7 +155,7 @@ class PaymentViewControllerTests: XCTestCase {
                                                 paymentFormStyle: nil,
                                                 billingFormStyle: nil,
                                                 supportedSchemes: [])
-    let testVC = PaymentViewController(viewModel: testViewModel)
+    let testVC = FramesPaymentViewController(viewModel: testViewModel)
     
     let expect = expectation(description: "Free up main thread in case UI work influences outcome")
     testVC.viewDidLoad()
@@ -183,7 +183,7 @@ class PaymentViewControllerTests: XCTestCase {
                                                 paymentFormStyle: nil,
                                                 billingFormStyle: nil,
                                                 supportedSchemes: [])
-    let testVC = PaymentViewController(viewModel: testViewModel)
+    let testVC = FramesPaymentViewController(viewModel: testViewModel)
     
     XCTAssertTrue(testLogger.addCalledWithMetadataPairs.isEmpty)
     XCTAssertTrue(testLogger.logCalledWithFramesLogEvents.isEmpty)


### PR DESCRIPTION
Rename the class due to naming conflicts in some projects.