### PR TITLE
fix: Using recommended resource_bundles in podspec to fix static linking

### DIFF
--- a/Frames.podspec
+++ b/Frames.podspec
@@ -15,7 +15,9 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Source/**/*.swift'
   s.exclude_files = "Classes/Exclude"
-  s.resources = 'Source/Resources/**'
+  s.resource_bundles = {
+    "Frames" => 'Source/Resources/**'
+  }
 
   s.dependency 'PhoneNumberKit'
   s.dependency 'CheckoutEventLoggerKit', '~> 1.2.4'


### PR DESCRIPTION
## Proposed changes

Replaced `resource` with recommended `resource_bundles` in Frames.podspec.

## Types of changes

What types of changes does your code introduce to Frames Ios?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] Lint and unit tests pass locally with my changes
* [not applicable] I have added tests that prove my fix is effective or that my feature works
* [not applicable] I have added necessary documentation (if appropriate)

## Further comments

There's an issue when adding `Frames` to a project through CocoaPods with `:linkage => :static` option that creates a compilation error due to a problem with duplicated `Assets.car` file. There are a few open tickets on this issue in cocoapods repository (for over 4 years) and the only recommended action that actually fixes the problem is to replace usage of `resource` with `resource_bundles`.

Ticket 1: https://github.com/CocoaPods/CocoaPods/issues/8122
Ticket 2: https://github.com/CocoaPods/CocoaPods/issues/8431

The second ticket is where we can see that many other repositories migrated to the usage of `resource_bundles` mentioning this issue. It is also the change suggested by the cocoapods team on the official site in the documentation:
> For building the Pod as a static library, we strongly recommend library developers to adopt resource bundles as there can be name collisions using the resources attribute.

Sources: 
 - https://guides.cocoapods.org/syntax/podspec.html#resource_bundles
 - https://guides.cocoapods.org/syntax/podspec.html#resources

As tested, this worked for both dynamic and static linkage options.
