### PR TITLE
Update sample project versions to exact versions

### DIFF
--- a/Checkout/Samples/CocoapodsSample/Podfile
+++ b/Checkout/Samples/CocoapodsSample/Podfile
@@ -5,6 +5,6 @@ target 'CheckoutCocoapodsSample' do
   use_frameworks!
 
   # Pods for CheckoutSDKCocoapodsSample
-  pod 'Checkout', '~> 4.0'
+  pod 'Checkout', '4.2.1'
 
 end

--- a/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
+++ b/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
@@ -1202,8 +1202,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/checkout/frames-ios";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				kind = exactVersion;
+				version = 4.2.1;
 			};
 		};
 		16C3F83E2A7927ED00690639 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/iOS Example Frame/Podfile
+++ b/iOS Example Frame/Podfile
@@ -6,7 +6,7 @@ target 'iOS Example Frame' do
   use_frameworks!
 
   # Pods for iOS Example Custom
-  pod 'Frames', '~> 4.0'
+  pod 'Frames', '4.2.1'
 
 end
 


### PR DESCRIPTION
We needed a trigger point to know if our latest release versions work. Because, sometimes the pods don't get updated and we use the old version without knowing. We also have a safety mechanism by doing this we have to get the new version numbers through PR reviews.