### PR TITLE
Add workflow to check PR status

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,122 @@
+name: Verify PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - 'main'
+      - 'develop'
+      - 'release/*'
+
+env:
+  destination: "platform=iOS Simulator,name=iPhone 14 Pro,OS=latest"
+  configuration: "Debug"
+  noIndex: "COMPILER_INDEX_STORE_ENABLE=NO"
+  noSigning: "CODE_SIGNING_ALLOWED=NO"
+  versionXcode: "14.3.1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checkout:
+    name: Checkout Verification
+    runs-on: macos-13
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -switch /Applications/Xcode_${versionXcode}.app && /usr/bin/xcodebuild -version
+
+      - name: Log xcodebuild Version
+        run: |
+          xcodebuild -version
+
+      - name: Run Checkout Tests
+        run: |
+          set -o pipefail && xcodebuild -scheme "${scheme}" test -destination "${destination}" "${noIndex}" "${noSigning}" | xcpretty
+        env:
+          scheme: CheckoutTests
+
+      - name: Build Checkout SPM Test Project
+        run: |
+          set -o pipefail && xcodebuild "build" "-project" "${path}" "-scheme" "${scheme}" "-configuration" "${configuration}" "-destination" "${destination}" "${noIndex}" "${noSigning}" | xcpretty
+        env:
+          path: "Checkout/Samples/SPMSample/CheckoutSPMSample.xcodeproj"
+          scheme: "CheckoutSPMSample"
+
+      - name: Checkout Pod Update
+        run: |
+          cd Checkout/Samples/CocoapodsSample
+          pod update
+
+      - name: Build Checkout CocoaPods Test Project
+        run: |
+          set -o pipefail && xcodebuild "build" "-workspace" "${path}" "-scheme" "${scheme}" "-configuration" "${configuration}" "-destination" "${destination}" "${noIndex}" "${noSigning}" | xcpretty
+        env:
+          path: "Checkout/Samples/CocoapodsSample/CheckoutCocoapodsSample.xcworkspace"
+          scheme: "CheckoutCocoapodsSample"
+
+  frames:
+    name: Frames Verification
+    runs-on: macos-13
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -switch /Applications/Xcode_${versionXcode}.app && /usr/bin/xcodebuild -version
+
+      - name: Log xcodebuild Version
+        run: |
+          xcodebuild -version
+
+      - name: Run Frames Unit Tests
+        run: |
+          set -o pipefail && xcodebuild -scheme "${scheme}" test -destination "${destination}" "${noIndex}" "${noSigning}" | xcpretty
+        env:
+          scheme: "FramesTests"
+
+      - name: Build Frames SPM Test Project
+        run: |
+          set -o pipefail && xcodebuild "build" "-project" "${path}" "-scheme" "${scheme}" "-configuration" "${configuration}" "-destination" "${destination}" "${noIndex}" "${noSigning}" | xcpretty
+        env:
+          path: "iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj"
+          scheme: "iOS Example Frame"
+
+      - name: Frames Pod Update
+        run: |
+          cd iOS\ Example\ Frame
+          pod update
+
+      - name: Build Frames CocoaPods Test Project
+        run: |
+          set -o pipefail && xcodebuild "build" "-workspace" "${path}" "-scheme" "${scheme}" "-configuration" "${configuration}" "-destination" "${destination}" "${noIndex}" "${noSigning}" | xcpretty
+        env:
+          path: "iOS Example Frame/iOS Example Frame.xcworkspace"
+          scheme: "iOS Example Frame"
+
+  run-ui-tests:
+    name: Run UI Tests
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log xcodebuild Version
+        run: |
+          xcodebuild -version
+
+      - name: Run UI Tests
+        run: |
+          set -o pipefail && xcodebuild test "-project" "${path}" "-scheme" "${scheme}" "-configuration" "${scheme}" "-destination" "${destination}"
+        env:
+          path: "iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj"
+          scheme: "UITest"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,10 @@ on:
   schedule:
     - cron: '34 2 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Check PR status via GitHub Actions. [JIRA](https://checkout.atlassian.net/browse/PIMOB-2127?atlOrigin=eyJpIjoiYTY1MWQ2MWFkYTdmNDcxMWE5OTAyNTc2OWEyYTljMTEiLCJwIjoiaiJ9)

Bitrise workflow to be removed with a separate PR. It's needed in this PR to prove that we didn't break anything. 

We needed to run tests other than the UI tests on `macOS-13` and `Xcode-14.3` since the other versions had a bug and were failing our tests.

The steps that are transferred from Bitrise:
<img width="216" alt="Screenshot 2023-08-31 at 11 29 05" src="https://github.com/checkout/frames-ios/assets/125963311/187e84f0-b6c9-45d5-ba60-b7be366e9f15">