### PR TITLE
Remove PR checks from Bitrise in favour of GitHub Actions

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,58 +1,7 @@
 format_version: "8"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: ios
-trigger_map:
-- pull_request_source_branch: '*'
-  workflow: pr-checks
 workflows:
-
-  _checkout-build-pods:
-    steps:
-    - cocoapods-install@2.2:
-        inputs:
-        - command: update
-        - podfile_path: $CHECKOUT_PODFILE
-    - script@1:
-        title: Build Checkout Pods Test project
-        inputs:
-        - content: |
-            xcodebuild "-workspace" "Checkout/Samples/CocoapodsSample/CheckoutCocoapodsSample.xcworkspace" "-scheme" "CheckoutCocoapodsSample" "-configuration" "Debug" "-destination" "name=iPhone 14 Pro" "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGNING_ALLOWED=NO" "build" | xcpretty
-    - cache-push@2: {}
-    after_run: []
-
-  _frames-build-pods:
-    steps:
-    - cocoapods-install@2.2:
-        inputs:
-        - podfile_path: $FRAMES_PODFILE
-    - script@1:
-        title: Build Pods Test project
-        inputs:
-        - content: |
-            xcodebuild "-workspace" "iOS Example Frame/iOS Example Frame.xcworkspace" "-scheme" "iOS Example Frame" "-configuration" "Debug" "-destination" "name=iPhone 14 Pro" "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGNING_ALLOWED=NO" "build" | xcpretty
-    - cache-push@2: {}
-    after_run: []
-
-  _checkout-build-spm:
-    steps:
-    - xcode-build-for-simulator@1:
-        title: Build Checkout SPM Test project
-        inputs:
-        - project_path: $CHECKOUT_SPM_PROJECT
-        - scheme: $CHECKOUT_APP_SCHEME
-    - deploy-to-bitrise-io@1: {}
-    - cache-push@2: {}
-
-  _frames-build-spm:
-    steps:
-    - xcode-build-for-simulator@1:
-        title: Build SPM Test project
-        inputs:
-        - project_path: $FRAMES_SPM_PROJECT
-        - scheme: $FRAMES_APP_SCHEME
-    - deploy-to-bitrise-io@1: {}
-    - cache-push@2: {}
-
   _frames-set-up:
     steps:
     - activate-ssh-key@4:
@@ -61,16 +10,6 @@ workflows:
     - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     after_run: []
-
-  _run-uitests:
-    steps:
-    - xcode-test:
-        inputs:
-        - project_path: $FRAMES_SPM_PROJECT
-        - scheme: $FRAMES_UITEST_SCHEME
-        - simulator_device: $UITEST_SIMULATOR_DEVICE
-    - deploy-to-bitrise-io@1: {}
-    - cache-push@2: {}
 
   _run-regression-tests:
     steps:
@@ -82,41 +21,6 @@ workflows:
         - simulator_device: $UITEST_SIMULATOR_DEVICE
     - deploy-to-bitrise-io@2.3: {}
     - cache-push@2: {}
-
-  _run-checkout-tests:
-    steps:
-    - script@1:
-        title: Run Checkout Unit Tests
-        inputs:
-        - content: |
-            xcodebuild -scheme CheckoutTests test -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=latest"
-    - deploy-to-bitrise-io@1: {}
-    - cache-push@2: {}
-
-  _run-frames-tests:
-    steps:
-    - script@1:
-        title: Run Frames Unit Tests
-        inputs:
-        - content: |
-            xcodebuild -scheme FramesTests test -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=latest"
-    - deploy-to-bitrise-io@1: {}
-    - cache-push@2: {}
-
-  frames-build-pods-release:
-    steps:
-    - cocoapods-install@1:
-        inputs:
-        - podfile_path: $FRAMES_PODFILE
-    - script@1:
-        title: Build Pods Test project
-        inputs:
-        - content: |
-            xcodebuild "-workspace" "iOS Example Frame/iOS Example Frame.xcworkspace" "-scheme" "iOS Example Frame" "-configuration" "Debug" "-destination" "name=iPhone 14 Pro" "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGNING_ALLOWED=NO" "build" | xcpretty
-    - cache-push@2: {}
-    after_run: []
-    before_run:
-    - _frames-set-up
 
   frames-deploy:
     steps:
@@ -152,43 +56,11 @@ workflows:
         inputs:
         - webhook_url: $FRAMES_IOS_BUILDS_CHANNEL
 
-  frames-pr-checks:
-    after_run:
-    - _frames-set-up
-    - _run-checkout-tests
-    - _checkout-build-pods
-    - _checkout-build-spm
-    - _run-frames-tests
-    - _frames-build-pods
-    - _frames-build-spm
-    - _run-uitests
-
   frames-regression-tests:
     after_run:
     - _frames-set-up
     - _run-regression-tests
-
-  frames-test-spm:
-    steps:
-    - activate-ssh-key@4:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@8: {}
-    - cache-pull@2: {}
-    - certificate-and-profile-installer@1: {}
-    - script@1:
-        title: Build SPM Test project
-        inputs:
-        - content: |
-            xcodebuild "-project" "iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj" "-scheme" "iOS Example Frame" "-configuration" "Debug" "-destination" "name=iPhone 14 Pro" "COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGNING_ALLOWED=NO" "build" | xcpretty
-    - cache-push@2: {}
-    - slack@3:
-        inputs:
-        - webhook_url: $FRAMES_IOS_BUILDS_CHANNEL
-
-  pr-checks:
-    after_run:
-    - frames-pr-checks
-
+    
 app:
   envs:
   - opts:


### PR DESCRIPTION
## Proposed changes

We're in the process of transferring all the Bitrise workflows into GitHub Actions workflows. We already merged `pr-checks` workflow, so, this PR removes the counterpart thereof.
