### PR TITLE
Add SwiftLint as a blocker pre-check for all the other checks

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -20,9 +20,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: SwiftLint
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Lint Edited Files
+        run: |
+          set -o pipefail
+          git fetch origin main
+          echo "Fetched"
+
+          # Use a conditional to check if there are edited files
+          if EDITED_FILES=$(git diff HEAD origin/main --name-only --diff-filter=d | grep "\.swift" | grep -v "\.swiftlint\.yml" | xargs echo | tr ' ' ','); then
+            echo "Got edited files"
+            echo $EDITED_FILES
+
+          # Check if EDITED_FILES is empty or null
+          if [ -z "$EDITED_FILES" ]; then
+            echo "No edited .swift files found."
+          else
+            swiftlint lint --strict $EDITED_FILES | sed -E 's/^(.*):([0-9]+):([0-9]+): (warning|error|[^:]+): (.*)/::\4 title=Lint error,file=\1,line=\2,col=\3::\5\n\1:\2:\3/'
+          fi
+          else
+            echo "No changes in .swift files found."
+          fi
+
   checkout:
     name: Checkout Verification
     runs-on: macos-13-xl
+    needs: lint
     
     steps:
       - name: Checkout
@@ -64,6 +94,7 @@ jobs:
   frames:
     name: Frames Verification
     runs-on: macos-13-xl
+    needs: lint
 
     steps:
       - name: Checkout
@@ -105,6 +136,7 @@ jobs:
   run-ui-tests:
     name: Run UI Tests
     runs-on: macos-12-xl
+    needs: lint
 
     steps:
       - name: Checkout

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,11 +1,16 @@
 included:
-    - Source
-    - iOS Example Frame
-    - iOS Example Frame Carthage
-    - iOS Example Frame SPM
+    - "Checkout"
+    - "Source"
+    - "iOS Example Frame"
+    - "iOS Example Frame SPM"
     
 excluded:
-    - iOS Example Frame/Pods
+    - "iOS Example Frame/Pods"
+    - "Checkout/Samples/CocoapodsSample/Pods"
+    - "CheckoutTests"
+    - "Tests"
+    - "iOS Example Frame SPM/iOS Example Frame Regression Tests"
+    - "iOS Example Frame/iOS Example FrameUITests"
      
 opt_in_rules:
     - array_init


### PR DESCRIPTION
- SwiftLint comes pre-installed on runner images of GitHub.
- SwiftLint will run before all the other checks. 
- If SwiftLint fails, then all the other checks don't run. This is made possible by the `needs:` mark.
- SwiftLint only runs for the new files to avoid a big PR
- It also parses errors and warnings for the new files and shows them on GitHub UI: (even though we won't get any warnings and will convert them to errors for new files. This is made possible by `--strict` flag. Parsing is made by using `sed -E`)

<img width="1161" alt="Screenshot 2023-09-11 at 12 45 17" src="https://github.com/checkout/frames-ios/assets/125963311/7098956c-a546-43d6-bb59-7cec933a309a">


- If there are no changes in `.swift` files, then it skips linting and marks the job as a success.

![Screenshot 2023-09-12 at 16 28 39](https://github.com/checkout/frames-ios/assets/125963311/bcdec35f-ffb2-443b-9e53-a4d2ebd7c7c6)

- If there are changes in `.swift` files, then SwiftLint only lints them: 

![Screenshot 2023-09-12 at 16 31 37](https://github.com/checkout/frames-ios/assets/125963311/4bba9b33-96c0-47e7-9344-3be9964c8241)
