### PR TITLE
Add only docs diff

### DIFF
--- a/.github/workflows/generate-jazzy-docs.yml
+++ b/.github/workflows/generate-jazzy-docs.yml
@@ -57,6 +57,6 @@ jobs:
         run: |
           git branch $BRANCH_NAME
           git checkout $BRANCH_NAME
-          git add .
+          git add ".github/docs"
           git commit -m "Update jazzy docs"
           git push -u origin $BRANCH_NAME --force


### PR DESCRIPTION
We don't need to add the updated `Podfile.lock` files to the branch that's created automatically