### PR TITLE
Update SnapshotTesting framework version

### DIFF
--- a/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
+++ b/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
@@ -1223,8 +1223,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				kind = exactVersion;
+				version = 1.12.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
We needed to define an exact version since they stopped supporting iOS 12 in a minor version release. This broke our CI/CD pipeline.
