### PR TITLE
Trigger regression and validation workflows via labels

### DIFF
--- a/.github/workflows/run-regression-tests.yml
+++ b/.github/workflows/run-regression-tests.yml
@@ -1,6 +1,10 @@
 name: Run Regression Tests
 
-on: workflow_dispatch
+on:
+  pull_request:
+    types: [ labeled ]
+
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -8,6 +12,7 @@ concurrency:
 
 jobs:
   run-regression-tests:
+    if: contains(github.event.pull_request.labels.*.name, 'Run Regression Tests')
     name: Run Regression Tests
     runs-on: macos-12-xl
 

--- a/.github/workflows/validate-for-app-store.yml
+++ b/.github/workflows/validate-for-app-store.yml
@@ -1,14 +1,19 @@
 name: Validate For App Store
 
-on: workflow_dispatch
+on:
+  pull_request:
+    types: [ labeled ]
+
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   validate_for_app_store:
-    name: Validate
+    if: contains(github.event.pull_request.labels.*.name, 'Validate For App Store')
+    name: Validate For App Store
     environment: AppStoreValidation
     runs-on: macos-12-xl
 


### PR DESCRIPTION
`Run Regression Tests` and `Validate App Store` was added as requirements for all the PRs that target the `main` branch. I hoped that we could manually run those two workflows and satisfy the PR requirements. But, PR status checks don't get updated even after those workflows succeed, if they are triggered manually. So, the only way to make it work is to trigger them via PR labels. 

I also left manual run capability in place, we can use it if need be. 