### PR TITLE
[Frames-iOS] - Allow billing address to be disabled on the prebuilt UI

### DIFF
--- a/CheckoutTests/Integration/CheckoutAPIServiceIntegrationTests.swift
+++ b/CheckoutTests/Integration/CheckoutAPIServiceIntegrationTests.swift
@@ -139,7 +139,7 @@ final class CheckoutAPIServiceIntegrationTests: XCTestCase {
         XCTAssertNil(tokenDetails.billingAddress)
         XCTAssertEqual(tokenDetails.cardCategory, "CONSUMER")
         XCTAssertEqual(tokenDetails.cardType, "DEBIT")
-        XCTAssertEqual(tokenDetails.issuer, "WISE PAYMENTS LIMITED")
+        XCTAssertEqual(tokenDetails.issuer, "CURVE UK LIMITED")
         XCTAssertEqual(tokenDetails.issuerCountry, "GB")
         XCTAssertNil(tokenDetails.phone)
         XCTAssertEqual(tokenDetails.productId, "MDW")

--- a/Source/UI/PaymentForm/Model/PaymentStyle.swift
+++ b/Source/UI/PaymentForm/Model/PaymentStyle.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct PaymentStyle {
     let paymentFormStyle: PaymentFormStyle
-    let billingFormStyle: BillingFormStyle
+    let billingFormStyle: BillingFormStyle?
 
     /**
      Define the payment form UI Styling
@@ -19,7 +19,7 @@ public struct PaymentStyle {
         - billingFormStyle: UI Styling for the billing form if the user will interact with the address billing
      */
     public init(paymentFormStyle: PaymentFormStyle,
-                billingFormStyle: BillingFormStyle) {
+                billingFormStyle: BillingFormStyle? = nil) {
         self.paymentFormStyle = paymentFormStyle
         self.billingFormStyle = billingFormStyle
     }

--- a/Source/UI/PaymentForm/ViewController/FramesPaymentViewController.swift
+++ b/Source/UI/PaymentForm/ViewController/FramesPaymentViewController.swift
@@ -344,7 +344,9 @@ extension FramesPaymentViewController {
       paymentViews.append(securityCodeView)
     }
 
-    if viewModel.paymentFormStyle?.addBillingSummary != nil && viewModel.paymentFormStyle?.editBillingSummary != nil {
+    if viewModel.billingFormStyle != nil &&
+        viewModel.paymentFormStyle?.addBillingSummary != nil &&
+        viewModel.paymentFormStyle?.editBillingSummary != nil {
       paymentViews.append(contentsOf: [
         addBillingFormButtonView,
         billingFormSummaryView])

--- a/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
+++ b/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
@@ -1235,8 +1235,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/checkout/frames-ios";
 			requirement = {
-				kind = exactVersion;
-				version = 4.3.0;
+				branch = "aashna/PIMOB-2358-disable_billing_address";
+				kind = branch;
 			};
 		};
 		16C3F83E2A7927ED00690639 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/iOS Example Frame/Podfile
+++ b/iOS Example Frame/Podfile
@@ -6,7 +6,7 @@ target 'iOS Example Frame' do
   use_frameworks!
 
   # Pods for iOS Example Custom
-  pod 'Frames', '4.3.0'
+  pod 'Frames', :git => 'https://github.com/checkout/frames-ios.git', :branch => 'aashna/PIMOB-2358-disable_billing_address'
 
 end
 

--- a/iOS Example Frame/iOS Example Frame/Factory/Factory.swift
+++ b/iOS Example Frame/iOS Example Frame/Factory/Factory.swift
@@ -36,10 +36,14 @@ enum Factory {
     let phone = Phone(number: "77 1234 1234", country: country)
 
     let billingFormData = BillingForm(name: "Bình Inyene", address: address, phone: phone)
-
+    
     let billingFormStyle = FramesFactory.defaultBillingFormStyle
 
     let paymentFormStyle = FramesFactory.defaultPaymentFormStyle
+      
+      // Comment out below lines to hide billing address (Optional)
+      // paymentFormStyle.editBillingSummary = nil
+      // paymentFormStyle.addBillingSummary = nil
 
     let supportedSchemes: [CardScheme] = [.mada, .visa, .mastercard, .maestro, .americanExpress, .discover, .dinersClub, .jcb]
 


### PR DESCRIPTION
## Issue
An SDK integrator is able to disable the billing address on the prebuilt UI. Currently they can only do this via the customisable UIs. When they disable the billing address, it doesn’t show on the prebuilt UI

_Issue ticket number and link._
[PIMOB-2358](https://checkout.atlassian.net/browse/PIMOB-2358)

## Proposed changes
Make billingFormStyle optional which will be checked against while creating default views.

## Test Steps

_If there's any functionality change, please list a step by step guide of how to verify the changes, and/or upload a screen recording for any visible changes._

> For instance:
> 1. Go to the main screen
> 2. Tap on Default
> 3. Verify the billing address view is removed

<img src="https://github.com/checkout/frames-ios/assets/156112796/49db10b8-d5d0-4504-8b14-fb1a5f0f1477" width="300" />

[PIMOB-2358]: https://checkout.atlassian.net/browse/PIMOB-2358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ