### PR TITLE
[Frames-iOS] - Update ReadMe with how to disable billing address

### DIFF
--- a/.github/partial-readmes/MakeItYourOwn.md
+++ b/.github/partial-readmes/MakeItYourOwn.md
@@ -37,6 +37,12 @@ paymentFormStyle.payButton.text = "Pay £54.63"
 ```
 We wouldn't recommend this approach if you're looking to override many values, since you would need to individually identify and change every property. But it can work for small tweaks.
 
+To deactivate the billing address, include the following code lines within the getDefaultPaymentViewController() function in the Factory.swift file:
+```swift
+    paymentFormStyle.editBillingSummary = nil
+    paymentFormStyle.addBillingSummary = nil
+```
+
 
 ### Use Theme
 In our Demo projects we also demo this approach in `ThemeDemo.swift`. With the Theme, we are aiming to give you a design system that you can use to create the full UI style by providing a small number of properties that we will share across to sub components. Since you might not fully agree with our mapping, you can still individually change each component afterwards (as in the Modify Default example).

--- a/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
+++ b/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
@@ -1235,7 +1235,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/checkout/frames-ios";
 			requirement = {
-				branch = "aashna/PIMOB-2358-disable_billing_address";
+				branch = "fix/update-readme";
 				kind = branch;
 			};
 		};

--- a/iOS Example Frame/Podfile
+++ b/iOS Example Frame/Podfile
@@ -6,7 +6,7 @@ target 'iOS Example Frame' do
   use_frameworks!
 
   # Pods for iOS Example Custom
-  pod 'Frames', :git => 'https://github.com/checkout/frames-ios.git', :branch => 'aashna/PIMOB-2358-disable_billing_address'
+  pod 'Frames', :git => 'https://github.com/checkout/frames-ios.git', :branch => 'fix/update-readme'
 
 end
 


### PR DESCRIPTION
UpdatedREADME to deactivate the billing address in Default view.

## Issue

README did not mention any way to deactivate billing address

_Issue ticket number and link._
[PIMOB-2355](https://checkout.atlassian.net/browse/PIMOB-2355)

## Proposed changes

README updated with how to disable the billing address

[PIMOB-2355]: https://checkout.atlassian.net/browse/PIMOB-2355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ