### PR TITLE
Make some workflows to be able to run manually

### DIFF
--- a/.github/workflows/run-regression-tests.yml
+++ b/.github/workflows/run-regression-tests.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   run-regression-tests:
-    if: contains(github.event.pull_request.labels.*.name, 'Run Regression Tests')
+    if: (github.event_name == 'workflow_dispatch') || (contains(github.event.pull_request.labels.*.name, 'Run Regression Tests'))
     name: Run Regression Tests
     runs-on: macos-12-xl
 

--- a/.github/workflows/validate-for-app-store.yml
+++ b/.github/workflows/validate-for-app-store.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   validate_for_app_store:
-    if: contains(github.event.pull_request.labels.*.name, 'Validate For App Store')
+    if: (github.event_name == 'workflow_dispatch') || contains(github.event.pull_request.labels.*.name, 'Validate For App Store')
     name: Validate For App Store
     environment: AppStoreValidation
     runs-on: macos-12-xl


### PR DESCRIPTION
- Add the capability of manual triggering for `Run Regression Tests` and `Validate For App Store` workflows
- Fix a failing regression test case