### PR TITLE
Let Publish Checkout.podspec and Publish Frames.podspec to be run from specific branches only

### DIFF
--- a/.github/workflows/publish-Checkout.podspec.yml
+++ b/.github/workflows/publish-Checkout.podspec.yml
@@ -7,7 +7,14 @@ jobs:
     environment: CocoaPodsRelease
     runs-on: macos-12-xl
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      
+      - name: Check current branch
+        run: |
+          if [[ "${GITHUB_REF#refs/heads/}" != "main" && "${GITHUB_REF#refs/heads/}" != release/* ]]; then
+            echo "This workflow is expected to run on the main or release branch only."
+            exit 1
+          fi
 
       - name: Publish Checkout.podspec
         run: |

--- a/.github/workflows/publish-Frames.podspec.yml
+++ b/.github/workflows/publish-Frames.podspec.yml
@@ -7,7 +7,14 @@ jobs:
     environment: CocoaPodsRelease
     runs-on: macos-12-xl
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      
+      - name: Check current branch
+        run: |
+          if [[ "${GITHUB_REF#refs/heads/}" != "main" && "${GITHUB_REF#refs/heads/}" != release/* ]]; then
+            echo "This workflow is expected to run on the main or release branch only."
+            exit 1
+          fi
 
       - name: Publish Frames.podspec
         run: |


### PR DESCRIPTION
We want to make sure that Publish Checkout.podspec and Publish Frames.podspec can only be run from a protected release/* branch and otherwise must fail. Added a step to check the current branch and fail if it's not the expected branch. 

[PIMOB-2409](https://checkout.atlassian.net/browse/PIMOB-2409)


[PIMOB-2409]: https://checkout.atlassian.net/browse/PIMOB-2409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ