### PR TITLE
Analyze CodeQL scanned files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,10 +45,17 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality
-
-    - name: Build
+        
+    - name: Build Frames
       run: |
         xcodebuild -scheme Frames -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=latest"
 
-    - name: Perform CodeQL Analysis
+    - name: Build FramesTests
+      run: |
+        xcodebuild -scheme FramesTests -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=latest" test
+
+    # Perform analysis on the code
+    - name: Analyze code with CodeQL
       uses: github/codeql-action/analyze@v2
+      with:
+          database: ${{ github.workspace }}


### PR DESCRIPTION
Initially, CodeQL was scanning 224/410 files because it was just taking Frames into account.
Added FramesTests also as part of CodeQL scan.
Now 304/410 files are being scanned.

[PIMOB-2428](https://checkout.atlassian.net/browse/PIMOB-2428)

[PIMOB-2428]: https://checkout.atlassian.net/browse/PIMOB-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ