### PR TITLE
Update/release preparation 4.3.2

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 
 #### 4.x Releases
 
+## [4.3.2](https://github.com/checkout/frames-ios/releases/tag/4.3.2)
+
+Released on 2024-03-01
+
+Updates:
+
+- Send risk data via Risk SDK for the opted-in customers. No public changes.
+
 ## [4.3.1](https://github.com/checkout/frames-ios/releases/tag/4.3.1)
 
 Released on 2024-01-19

--- a/Checkout.podspec
+++ b/Checkout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Checkout'
-  s.version = '4.3.0'
+  s.version = '4.3.2'
   s.summary = 'Checkout SDK for iOS'
 
   s.description = <<-DESC

--- a/Checkout/Samples/CocoapodsSample/Podfile
+++ b/Checkout/Samples/CocoapodsSample/Podfile
@@ -5,6 +5,6 @@ target 'CheckoutCocoapodsSample' do
   use_frameworks!
 
   # Pods for CheckoutSDKCocoapodsSample
-  pod 'Checkout', '4.2.1'
+  pod 'Checkout', '4.3.2'
 
 end

--- a/Checkout/Samples/SPMSample/CheckoutSPMSample.xcodeproj/project.pbxproj
+++ b/Checkout/Samples/SPMSample/CheckoutSPMSample.xcodeproj/project.pbxproj
@@ -511,8 +511,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/checkout/frames-ios";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				kind = exactVersion;
+				version = 4.3.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Checkout/Samples/SPMSample/CheckoutSPMSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Checkout/Samples/SPMSample/CheckoutSPMSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,12 +10,30 @@
       }
     },
     {
+      "identity" : "checkout-risk-sdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/checkout/checkout-risk-sdk-ios.git",
+      "state" : {
+        "revision" : "4823f05166dca8392a41b56b975515c7e0f1a8da",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "fingerprintjs-pro-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/fingerprintjs/fingerprintjs-pro-ios",
+      "state" : {
+        "revision" : "ceb8b845ec99727ee9f78869a51688c6daa16bd8",
+        "version" : "2.2.0"
+      }
+    },
+    {
       "identity" : "frames-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/checkout/frames-ios",
       "state" : {
-        "revision" : "24a4585e5b7da1cc4b062e5aeadc63f1c9024db4",
-        "version" : "4.2.0"
+        "revision" : "2dae4f877e3a1882172c749e3bf4c32228b9d6a3",
+        "version" : "4.3.2"
       }
     },
     {

--- a/Checkout/Source/Validation/Constants.swift
+++ b/Checkout/Source/Validation/Constants.swift
@@ -25,7 +25,7 @@ public enum Constants {
     }
 
   enum Product {
-    static let version = "4.3.0"
+    static let version = "4.3.2"
     static let name = "checkout-ios-sdk"
     static let userAgent = "checkout-sdk-ios/\(version)"
   }

--- a/Frames.podspec
+++ b/Frames.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Frames"
-  s.version      = "4.3.1"
+  s.version      = "4.3.2"
   s.summary      = "Checkout API Client, Payment Form UI and Utilities in Swift"
   s.description  = <<-DESC
   Checkout API Client and Payment Form Utilities in Swift.
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'PhoneNumberKit'
   s.dependency 'CheckoutEventLoggerKit', '~> 1.2.4'
-  s.dependency 'Checkout', '4.3.0'
+  s.dependency 'Checkout', '4.3.2'
 
 end

--- a/Source/Core/Constants/Constants.swift
+++ b/Source/Core/Constants/Constants.swift
@@ -8,7 +8,7 @@
 enum Constants {
 
     static let productName = "frames-ios-sdk"
-    static let version = "4.3.1"
+    static let version = "4.3.2"
     static let userAgent = "checkout-sdk-frames-ios/\(version)"
 
     enum Logging {

--- a/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
+++ b/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
@@ -1238,8 +1238,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/checkout/frames-ios";
 			requirement = {
-				branch = "PRISM-10522-risk-i-os-is-added-to-frames-i-os";
-				kind = branch;
+				kind = exactVersion;
+				version = 4.3.2;
 			};
 		};
 		16C3F83E2A7927ED00690639 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/checkout/frames-ios",
       "state" : {
-        "branch" : "PRISM-10522-risk-i-os-is-added-to-frames-i-os",
-        "revision" : "de71eed3638875dac5af1d3ca01de6e5704420ea"
+        "revision" : "2dae4f877e3a1882172c749e3bf4c32228b9d6a3",
+        "version" : "4.3.2"
       }
     },
     {

--- a/iOS Example Frame/Podfile
+++ b/iOS Example Frame/Podfile
@@ -6,8 +6,7 @@ target 'iOS Example Frame' do
   use_frameworks!
 
   # Pods for iOS Example Custom
-  # pod 'Frames', '4.3.1'
-  pod 'Frames', :git => 'https://github.com/checkout/frames-ios', :branch => 'PRISM-10522-risk-i-os-is-added-to-frames-i-os'
+  pod 'Frames', '4.3.2'
 
 end
 


### PR DESCRIPTION
Bump versions to prepare a new release v4.3.2 for `Checkout` and `Frames`

Ticket on release board is [here](https://checkout.atlassian.net/browse/RELEASE-27506?atlOrigin=eyJpIjoiODY2ODA0ZWQ2ZjIwNDEzNjhiYjg4MjViN2QwYThkZTAiLCJwIjoiaiJ9).