### PR TITLE
Bump Checkout pod deployment target to iOS 12

### DIFF
--- a/Checkout.podspec
+++ b/Checkout.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.author   = { "Checkout.com Integration" => "integration@checkout.com" }
   s.source   = { :git => "https://github.com/checkout/frames-ios.git", :tag => s.version }
 
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   s.swift_version = "5.7"
 
   s.source_files = 'Checkout/Source/**/*.swift'


### PR DESCRIPTION
We were having [dependency errors](https://github.com/checkout/frames-ios/actions/runs/8115018132/job/22181948511) whilst trying to publish Checkout pod. It needs to support iOS 12 upwards.