### PR TITLE
Update how Frames options are sent to Risk SDK

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   lint:
     name: SwiftLint
-    runs-on: macos-latest
+    runs-on: macos-13-large
 
     steps:
       - name: Checkout
@@ -33,7 +33,7 @@ jobs:
 
   checkout:
     name: Checkout Verification
-    runs-on: macos-13-xl
+    runs-on: macos-13-xlarge
     needs: lint
     
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   frames:
     name: Frames Verification
-    runs-on: macos-13-xl
+    runs-on: macos-13-xlarge
     needs: lint
 
     steps:

--- a/Checkout.podspec
+++ b/Checkout.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.exclude_files = "Checkout/Samples/**"
 
   s.dependency 'CheckoutEventLoggerKit', '~> 1.2.4'
-  s.dependency 'Risk', '2.0.3'
+  s.dependency 'Risk', '3.0.0'
 
 end

--- a/Checkout/Source/Tokenisation/CheckoutAPIService.swift
+++ b/Checkout/Source/Tokenisation/CheckoutAPIService.swift
@@ -59,9 +59,6 @@ final public class CheckoutAPIService: CheckoutAPIProtocol {
       riskEnvironment = .sandbox
     }
       
-    let riskConfig = RiskConfig(publicKey: publicKey, environment: riskEnvironment, framesMode: true, correlationId: logManager.correlationID)
-    let riskSDK = Risk.init(config: riskConfig)
-      
     logManager.setup(
       environment: environment,
       logger: CheckoutEventLogger(productName: Constants.Product.name),
@@ -69,6 +66,10 @@ final public class CheckoutAPIService: CheckoutAPIProtocol {
       dateProvider: DateProvider(),
       anyCodable: AnyCodable()
     )
+    
+    let framesOptions = FramesOptions(productIdentifier: Constants.Product.name, version: Constants.Product.version, correlationId: logManager.correlationID)
+    let riskConfig = RiskConfig(publicKey: publicKey, environment: riskEnvironment, framesOptions: framesOptions)
+    let riskSDK = Risk.init(config: riskConfig)
 
     self.init(
       publicKey: publicKey,

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/checkout/checkout-risk-sdk-ios.git",
       "state" : {
-        "revision" : "a5df46ecd4324661459faa9e9ac18d627b4d26aa",
-        "version" : "2.0.3"
+        "revision" : "d9d8bcbc18ad63e3ce5bf4bb1f34ce5b3508a84b",
+        "version" : "3.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             exact: "3.5.9"),
         .package(
             url: "https://github.com/checkout/checkout-risk-sdk-ios.git",
-            exact: "2.0.3"),
+            exact: "3.0.0"),
         .package(
             url: "https://github.com/checkout/checkout-event-logger-ios-framework.git",
             from: "1.2.4"


### PR DESCRIPTION
## Issue

https://checkout.atlassian.net/browse/PRISM-11216

## Proposed changes

- Updates the Risk SDK version to 3.0.0 which adds correlationID as a metadata instead of a direct event arguement which also changes the structure of receiving the frames options collecting more data(product name, version and correlationID) to improve the log tracing.
- Moves Risk config and initialisation after the log manager initialisation since the `setup` method calls a `resetCorrelationID` method which updates the correlationID.

## Test Steps
No internal changes made.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if applicable)
