### PR TITLE
Bump sample project versions to 4.3.5

### DIFF
--- a/.github/workflows/validate-for-app-store.yml
+++ b/.github/workflows/validate-for-app-store.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'workflow_dispatch') || contains(github.event.pull_request.labels.*.name, 'Validate For App Store')
     name: Validate For App Store
     environment: AppStoreValidation
-    runs-on: macos-12-xl
+    runs-on: macos-latest
 
     steps:
       - name: Checkout repository

--- a/Checkout.podspec
+++ b/Checkout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Checkout'
-  s.version = '4.3.4'
+  s.version = '4.3.5'
   s.summary = 'Checkout SDK for iOS'
 
   s.description = <<-DESC

--- a/Checkout/Samples/CocoapodsSample/Podfile
+++ b/Checkout/Samples/CocoapodsSample/Podfile
@@ -5,6 +5,6 @@ target 'CheckoutCocoapodsSample' do
   use_frameworks!
 
   # Pods for CheckoutSDKCocoapodsSample
-  pod 'Checkout', '4.3.4'
+  pod 'Checkout', '4.3.5'
 
 end

--- a/Checkout/Samples/SPMSample/CheckoutSPMSample.xcodeproj/project.pbxproj
+++ b/Checkout/Samples/SPMSample/CheckoutSPMSample.xcodeproj/project.pbxproj
@@ -512,7 +512,7 @@
 			repositoryURL = "https://github.com/checkout/frames-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.3.4;
+				version = 4.3.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Checkout/Source/Validation/Constants.swift
+++ b/Checkout/Source/Validation/Constants.swift
@@ -25,7 +25,7 @@ public enum Constants {
     }
 
   enum Product {
-    static let version = "4.3.3"
+    static let version = "4.3.5"
     static let name = "checkout-ios-sdk"
     static let userAgent = "checkout-sdk-ios/\(version)"
   }

--- a/Frames.podspec
+++ b/Frames.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Frames"
-  s.version      = "4.3.4"
+  s.version      = "4.3.5"
   s.summary      = "Checkout API Client, Payment Form UI and Utilities in Swift"
   s.description  = <<-DESC
   Checkout API Client and Payment Form Utilities in Swift.
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'PhoneNumberKit'
   s.dependency 'CheckoutEventLoggerKit', '~> 1.2.4'
-  s.dependency 'Checkout', '4.3.4'
+  s.dependency 'Checkout', '4.3.5'
 
 end

--- a/Source/Core/Constants/Constants.swift
+++ b/Source/Core/Constants/Constants.swift
@@ -8,7 +8,7 @@
 enum Constants {
 
     static let productName = "frames-ios-sdk"
-    static let version = "4.3.3"
+    static let version = "4.3.5"
     static let userAgent = "checkout-sdk-frames-ios/\(version)"
 
     enum Logging {

--- a/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
+++ b/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
@@ -1239,7 +1239,7 @@
 			repositoryURL = "https://github.com/checkout/frames-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.3.4;
+				version = 4.3.5;
 			};
 		};
 		16C3F83E2A7927ED00690639 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/iOS Example Frame/Podfile
+++ b/iOS Example Frame/Podfile
@@ -6,7 +6,7 @@ target 'iOS Example Frame' do
   use_frameworks!
 
   # Pods for iOS Example Custom
-  pod 'Frames', '4.3.4'
+  pod 'Frames', '4.3.5'
  
 end
 


### PR DESCRIPTION
Uses the new version of Risk SDK. We were getting reports of a crash relevant to RIsk SDK logging improvement. The issue did not happen in 4.3.2 but only on 4.3.3 and 4.3.4. We couldn’t reproduce the crash and it’s intermittent for client developers as well. We wanted to do our best bet and alter the usage of logger SDK in Risk SDK. We’ll release version 4.3.5 and add some warning labels for v4.3.3 and v4.3.4. We won’t retire or roll them back, because unless someone intentionally uses those versions, they will be skipped by SPM’s automatic dependency resolver and all the client apps will be updated to 4.3.5 in their next iteration of app compilations.

Will address #526 