### PR TITLE
Bump versions/4.3.6

### DIFF
--- a/Checkout.podspec
+++ b/Checkout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Checkout'
-  s.version = '4.3.5'
+  s.version = '4.3.6'
   s.summary = 'Checkout SDK for iOS'
 
   s.description = <<-DESC

--- a/Checkout/Samples/CocoapodsSample/Podfile
+++ b/Checkout/Samples/CocoapodsSample/Podfile
@@ -5,6 +5,6 @@ target 'CheckoutCocoapodsSample' do
   use_frameworks!
 
   # Pods for CheckoutSDKCocoapodsSample
-  pod 'Checkout', '4.3.5'
+  pod 'Checkout', '4.3.6'
 
 end

--- a/Checkout/Samples/SPMSample/CheckoutSPMSample.xcodeproj/project.pbxproj
+++ b/Checkout/Samples/SPMSample/CheckoutSPMSample.xcodeproj/project.pbxproj
@@ -512,7 +512,7 @@
 			repositoryURL = "https://github.com/checkout/frames-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.3.5;
+				version = 4.3.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Frames.podspec
+++ b/Frames.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Frames"
-  s.version      = "4.3.5"
+  s.version      = "4.3.6"
   s.summary      = "Checkout API Client, Payment Form UI and Utilities in Swift"
   s.description  = <<-DESC
   Checkout API Client and Payment Form Utilities in Swift.
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'PhoneNumberKit'
   s.dependency 'CheckoutEventLoggerKit', '~> 1.2.4'
-  s.dependency 'Checkout', '4.3.5'
+  s.dependency 'Checkout', '4.3.6'
 
 end

--- a/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
+++ b/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
@@ -1239,7 +1239,7 @@
 			repositoryURL = "https://github.com/checkout/frames-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.3.5;
+				version = 4.3.6;
 			};
 		};
 		16C3F83E2A7927ED00690639 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/iOS Example Frame/Podfile
+++ b/iOS Example Frame/Podfile
@@ -6,7 +6,7 @@ target 'iOS Example Frame' do
   use_frameworks!
 
   # Pods for iOS Example Custom
-  pod 'Frames', '4.3.5'
+  pod 'Frames', '4.3.6'
  
 end
 


### PR DESCRIPTION
Fixes a crash that's been sourced by Risk SDK