### PR TITLE
Implement timeout for Risk SDK

### DIFF
--- a/Checkout/Samples/CocoapodsSample/Podfile
+++ b/Checkout/Samples/CocoapodsSample/Podfile
@@ -5,6 +5,7 @@ target 'CheckoutCocoapodsSample' do
   use_frameworks!
 
   # Pods for CheckoutSDKCocoapodsSample
-  pod 'Checkout', '4.3.6'
+# pod 'Checkout', '4.3.7'
+  pod 'Checkout', :git => 'https://github.com/checkout/frames-ios.git', :branch => 'feature/risk-sdk-timeout-recovery'
 
 end

--- a/Checkout/Source/Logging/CheckoutLogEvent.swift
+++ b/Checkout/Source/Logging/CheckoutLogEvent.swift
@@ -19,6 +19,7 @@ enum CheckoutLogEvent: Equatable {
   case cvvRequested(SecurityCodeTokenRequestData)
   case cvvResponse(SecurityCodeTokenRequestData, TokenResponseData)
   case riskSDKCompletion
+  case riskSDKTimeOut
 
   func event(date: Date) -> Event {
     Event(
@@ -58,6 +59,8 @@ enum CheckoutLogEvent: Equatable {
       return "card_validator_cvv"
     case .riskSDKCompletion:
       return "risk_sdk_completion"
+    case .riskSDKTimeOut:
+      return "risk_sdk_time_out"
     }
   }
 
@@ -70,7 +73,8 @@ enum CheckoutLogEvent: Equatable {
       .validateExpiryInteger,
       .validateCVV,
       .cvvRequested,
-      .riskSDKCompletion:
+      .riskSDKCompletion,
+      .riskSDKTimeOut:
       return .info
     case .tokenResponse(_, let tokenResponseData),
         .cvvResponse(_, let tokenResponseData):
@@ -93,7 +97,8 @@ enum CheckoutLogEvent: Equatable {
       .validateExpiryString,
       .validateExpiryInteger,
       .validateCVV,
-      .riskSDKCompletion:
+      .riskSDKCompletion,
+      .riskSDKTimeOut:
       return [:]
     case let .tokenRequested(tokenRequestData):
       return [

--- a/CheckoutTests/Stubs/StubRisk.swift
+++ b/CheckoutTests/Stubs/StubRisk.swift
@@ -14,15 +14,24 @@ class StubRisk: RiskProtocol {
     
     var configureCalledCount = 0
     var publishDataCalledCount = 0
-    
+
+    // If set to false, Risk SDK will hang and not call the completion block for that specific function.
+    // It will mimic the behaviour of a bug we have. We need to call Frames's completion block after the defined timeout period in that case.
+    var shouldConfigureFunctionCallCompletion: Bool = true
+    var shouldPublishFunctionCallCompletion: Bool = true
+
     func configure(completion: @escaping (Result<Void, RiskError.Configuration>) -> Void) {
         configureCalledCount += 1
-        completion(.success(()))
+        if shouldConfigureFunctionCallCompletion {
+          completion(.success(()))
+        }
     }
     
     func publishData (cardToken: String? = nil, completion: @escaping (Result<PublishRiskData, RiskError.Publish>) -> Void) {
         publishDataCalledCount += 1
-        completion(.success(PublishRiskData(deviceSessionId: "dsid_testDeviceSessionId")))
+        if shouldPublishFunctionCallCompletion {
+          completion(.success(PublishRiskData(deviceSessionId: "dsid_testDeviceSessionId")))
+        }
     }
 }
 

--- a/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
+++ b/iOS Example Frame SPM/iOS Example Frame SPM.xcodeproj/project.pbxproj
@@ -1238,8 +1238,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/checkout/frames-ios";
 			requirement = {
-				kind = exactVersion;
-				version = 4.3.6;
+				branch = "feature/risk-sdk-timeout-recovery";
+				kind = branch;
 			};
 		};
 		16C3F83E2A7927ED00690639 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/iOS Example Frame/Podfile
+++ b/iOS Example Frame/Podfile
@@ -6,7 +6,8 @@ target 'iOS Example Frame' do
   use_frameworks!
 
   # Pods for iOS Example Custom
-  pod 'Frames', '4.3.6'
+# pod 'Frames', '4.3.6'
+  pod 'Frames', :git => 'https://github.com/checkout/frames-ios.git', :branch => 'feature/risk-sdk-timeout-recovery'
  
 end
 


### PR DESCRIPTION
## Issue

[PIMOB-2696](https://checkout.atlassian.net/browse/PIMOB-2696?atlOrigin=eyJpIjoiMjljNzBkOWI1M2Q0NGExMWI1ZmI1YTI4MGNlMTEzYmUiLCJwIjoiaiJ9)

Unblocks #542 

## Proposed changes

Risk team had a development that made Frames’s completion block to await their completion. This ended up with some merchants getting blocked by the response of Risk SDK. We had a long chat and decided the issue is because of another 3rd party dependency that the Risk SDK uses: FingerPrint SDK. Now we agreed with the Risk team to have a Frames development to timeout after a definitive timeframe to stop waiting for Risk SDK result and just call the callback with the token that’s already at hand.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ✅ ] Reviewers assigned
* [ ✅ ] I have performed a self-review of my code and manual testing
* [ ✅ ] Lint and unit tests pass locally with my changes
* [ ✅ ] I have added tests that prove my fix is effective or that my feature works
* [ ✅ ] I have added necessary documentation (if applicable)

[PIMOB-2696]: https://checkout.atlassian.net/browse/PIMOB-2696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ