### PR TITLE
Update PhoneNumberKit to 3.8.0 - Fixes Swift 6 Builds

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/marmelroy/PhoneNumberKit.git",
       "state" : {
-        "revision" : "6edd6e38a30aec087cb97f7377edf876c29a427e",
-        "version" : "3.5.9"
+        "revision" : "c107075aa8d394be7aced273a46e944afe8b321b",
+        "version" : "3.8.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/marmelroy/PhoneNumberKit.git",
-            exact: "3.5.9"),
+            exact: "3.8.0"),
         .package(
             url: "https://github.com/checkout/checkout-risk-sdk-ios.git",
             exact: "3.0.2"),


### PR DESCRIPTION
## Issue
Swift 6 Builds fail

## Fix

PhoneNumberKit made a release last week fixing builds in Swift 6 as per the change log here: https://github.com/marmelroy/PhoneNumberKit/releases/tag/3.8.0

This PR updates the Package.swift as well as the Package.resolved.